### PR TITLE
Marketing info is not validated at instantiation

### DIFF
--- a/contracts/seilor/src/contract.rs
+++ b/contracts/seilor/src/contract.rs
@@ -43,14 +43,22 @@ pub fn instantiate(
         cap: Some(msg.max_supply.into()),
     });
 
-    if let Some(marketing) = cw20_instantiate_msg.marketing {
-        cw20_instantiate_msg.marketing = Some(InstantiateMarketingInfo {
+    cw20_instantiate_msg.marketing = if let Some(marketing) = cw20_instantiate_msg.marketing {
+        Some(InstantiateMarketingInfo {
             project: marketing.project,
             description: marketing.description,
             logo: marketing.logo,
-            marketing: Some(gov.to_string()),
-        });
-    }
+            marketing: Some(
+                marketing
+                    .marketing
+                    .unwrap_or_else(|| gov.clone().to_string()),
+            ),
+        })
+    } else {
+        return Err(ContractError::Std(StdError::generic_err(
+            "Missing marketing info",
+        )));
+    };
 
     let ins_res = cw20_instantiate(deps.branch(), env, info, cw20_instantiate_msg);
     if let Err(err) = ins_res {

--- a/contracts/ve_seilor/src/contract.rs
+++ b/contracts/ve_seilor/src/contract.rs
@@ -51,10 +51,14 @@ pub fn instantiate(
             project: marketing.project,
             description: marketing.description,
             logo: marketing.logo,
-            marketing: Option::from(gov.clone().to_string()),
+            marketing: Some(
+                marketing
+                    .marketing
+                    .unwrap_or_else(|| gov.clone().to_string()),
+            ),
         })
     } else {
-        None
+        return Err(ContractError::MissingMarketingInfo {});
     };
 
     let ins_res = cw20_instantiate(deps.branch(), env, info, cw20_instantiate_msg);

--- a/contracts/ve_seilor/src/error.rs
+++ b/contracts/ve_seilor/src/error.rs
@@ -17,4 +17,7 @@ pub enum ContractError {
 
     #[error("Unable initial balances")]
     UnableInitialBalances {},
+
+    #[error("Missing marketing info")]
+    MissingMarketingInfo {},
 }

--- a/contracts/ve_seilor/src/testing/tests.rs
+++ b/contracts/ve_seilor/src/testing/tests.rs
@@ -439,7 +439,10 @@ mod tests {
         let _res = execute(deps.as_mut(), mock_env(), _info, _msg).unwrap();
         assert_eq!(0, _res.messages.len());
 
-        assert_eq!(get_balance(deps.as_ref(), "lucky"), Uint128::from(112232u128));
+        assert_eq!(
+            get_balance(deps.as_ref(), "lucky"),
+            Uint128::from(112232u128)
+        );
 
         // Positive test case by minter
         let _msg = ExecuteMsg::Burn {
@@ -450,6 +453,9 @@ mod tests {
         let _res = execute(deps.as_mut(), mock_env(), _info, _msg).unwrap();
         assert_eq!(1, _res.messages.len());
 
-        assert_eq!(get_balance(deps.as_ref(), "lucky"), Uint128::from(112231u128));
+        assert_eq!(
+            get_balance(deps.as_ref(), "lucky"),
+            Uint128::from(112231u128)
+        );
     }
 }


### PR DESCRIPTION
Fixed issues -2
If marketing info is not included at instantiation, the execute_update_marketing and execute_upload_logo functions will always return an Unauthorized error message because marketing is None. The affected contracts are the following:

krp-token-contracts/seilor
krp-token-contracts/ve_seilor
It is recommended to ensure that marketing and marketing.marketing are different to None when instantiating the contract.