### PR TITLE
Unused messages

### DIFF
--- a/contracts/ve_seilor/src/contract.rs
+++ b/contracts/ve_seilor/src/contract.rs
@@ -3,9 +3,7 @@ use crate::handler::{burn, mint, set_minters, update_config};
 use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 use crate::querier::{query_is_minter, query_vote_config};
 use crate::state::{store_vote_config, VoteConfig};
-use crate::ve_querier::{
-    checkpoints, get_past_total_supply, get_past_votes, get_votes, num_checkpoints,
-};
+use crate::ve_querier::{checkpoints, get_past_votes, get_votes, num_checkpoints};
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::Uint128;
@@ -149,9 +147,9 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
             account,
             block_number,
         } => to_binary(&get_past_votes(deps, env, account, block_number)?),
-        QueryMsg::GetPastTotalSupply { block_number } => {
-            to_binary(&get_past_total_supply(deps, env, block_number)?)
-        }
+        // QueryMsg::GetPastTotalSupply { block_number } => {
+        //     to_binary(&get_past_total_supply(deps, env, block_number)?)
+        // }
 
         // inherited from cw20-base
         QueryMsg::Balance { address } => to_binary(&query_balance(deps, address)?),

--- a/contracts/ve_seilor/src/msg.rs
+++ b/contracts/ve_seilor/src/msg.rs
@@ -1,5 +1,5 @@
+use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Uint128};
-use cosmwasm_schema::{cw_serde,QueryResponses};
 use cw20::Logo;
 
 use cw20_base::msg::InstantiateMsg as Cw20InstantiateMsg;
@@ -16,18 +16,24 @@ pub struct InstantiateMsg {
 
 #[cw_serde]
 pub enum ExecuteMsg {
-    UpdateConfig{
+    UpdateConfig {
         max_minted: Option<Uint128>,
         fund: Option<Addr>,
         gov: Option<Addr>,
     },
     SetMinters {
         contracts: Vec<Addr>,
-        is_minter: Vec<bool>
+        is_minter: Vec<bool>,
     },
-    Mint { recipient: String, amount: Uint128 },
+    Mint {
+        recipient: String,
+        amount: Uint128,
+    },
     /// Implements CW20. Burn is a base message to destroy tokens forever
-    Burn { user: String, amount: Uint128 },
+    Burn {
+        user: String,
+        amount: Uint128,
+    },
 
     /// Only with the "marketing" extension. If authorized, updates marketing metadata.
     /// Setting None/null for any of these will leave it unchanged.
@@ -48,22 +54,21 @@ pub enum ExecuteMsg {
 #[derive(QueryResponses)]
 pub enum QueryMsg {
     #[returns(VoteConfigResponse)]
-    VoteConfig{},
+    VoteConfig {},
     #[returns(IsMinterResponse)]
     IsMinter { address: String },
     #[returns(CheckpointResponse)]
-    Checkpoints {account: Addr, pos: u32},
+    Checkpoints { account: Addr, pos: u32 },
     #[returns(NumCheckpointsResponse)]
-    NumCheckpoints{account: Addr},
+    NumCheckpoints { account: Addr },
     // #[returns(DelegatesResponse)]
     // Delegates { account: Addr },
     #[returns(GetVotesResponse)]
-    GetVotes{account:Addr},
+    GetVotes { account: Addr },
     #[returns(GetPastVotesResponse)]
-    GetPastVotes{account:Addr, block_number:u64},
-    #[returns(GetPastTotalSupplyResponse)]
-    GetPastTotalSupply{block_number:u64},
-
+    GetPastVotes { account: Addr, block_number: u64 },
+    // #[returns(GetPastTotalSupplyResponse)]
+    // GetPastTotalSupply{block_number:u64},
     /// Implements CW20. Returns the current balance of the given address, 0 if unset.
     #[returns(cw20::BalanceResponse)]
     Balance { address: String },
@@ -113,10 +118,10 @@ pub enum QueryMsg {
     DownloadLogo {},
 }
 
-#[cw_serde]
-pub struct GetPastTotalSupplyResponse {
-    pub total_supply: u128,
-}
+// #[cw_serde]
+// pub struct GetPastTotalSupplyResponse {
+//     pub total_supply: u128,
+// }
 #[cw_serde]
 pub struct GetPastVotesResponse {
     pub votes: u128,
@@ -138,9 +143,7 @@ pub struct NumCheckpointsResponse {
 
 #[cw_serde]
 pub enum FundMsg {
-    RefreshReward {
-        account: Addr,
-    },
+    RefreshReward { account: Addr },
 }
 
 #[cw_serde]
@@ -148,13 +151,12 @@ pub struct VoteConfigResponse {
     pub max_supply: u128,
     pub fund: Addr,
     pub gov: Addr,
-    pub max_minted:Uint128,
-    pub total_minted:Uint128,
+    pub max_minted: Uint128,
+    pub total_minted: Uint128,
 }
 
-
 #[cw_serde]
-pub struct CheckpointResponse{
+pub struct CheckpointResponse {
     pub from_block: u64,
     pub votes: u128,
 }
@@ -164,9 +166,5 @@ pub struct IsMinterResponse {
     pub is_minter: bool,
 }
 
-
-
 #[cw_serde]
 pub struct MigrateMsg {}
-
-

--- a/contracts/ve_seilor/src/state.rs
+++ b/contracts/ve_seilor/src/state.rs
@@ -5,7 +5,6 @@ use cosmwasm_std::{Addr, StdError, StdResult, Storage, Uint128};
 
 use cw_storage_plus::{Item, Map};
 
-
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Checkpoint {
     pub from_block: u64,
@@ -22,16 +21,15 @@ pub struct VoteConfig {
     pub max_supply: u128,
     pub fund: Addr,
     pub gov: Addr,
-    pub max_minted:Uint128,
-    pub total_minted:Uint128,
+    pub max_minted: Uint128,
+    pub total_minted: Uint128,
 }
 
 // const DELEGATES: Map<Addr, Addr> = Map::new("delegates");
 const CHECK_POINTS: Map<Addr, Vec<Checkpoint>> = Map::new("checkpoints");
-const VOTE_INFO: Item<VoteInfo> = Item::new("vote_info");
+// const VOTE_INFO: Item<VoteInfo> = Item::new("vote_info");
 const VOTE_CONFIG: Item<VoteConfig> = Item::new("vote_config");
 const MINTERS: Map<Addr, bool> = Map::new("minters");
-
 
 // pub fn store_delegates(storage: &mut dyn Storage, delegator: Addr, delegate: &Addr) -> StdResult<()> {
 //     DELEGATES.save(storage, delegator, delegate)?;
@@ -42,12 +40,15 @@ const MINTERS: Map<Addr, bool> = Map::new("minters");
 //     DELEGATES.may_load(storage, delegator)?.ok_or_else(|| StdError::generic_err("Delegate not found"))
 // }
 
-
 // pub fn read_delegates_default(storage: &dyn Storage, delegator: Addr) -> StdResult<Addr> {
 //     Ok(DELEGATES.may_load(storage, delegator)?.unwrap_or(Addr::unchecked("")))
 // }
 
-pub fn store_checkpoints(storage: &mut dyn Storage, delegator: Addr, checkpoints: &Vec<Checkpoint>) -> StdResult<()> {
+pub fn store_checkpoints(
+    storage: &mut dyn Storage,
+    delegator: Addr,
+    checkpoints: &Vec<Checkpoint>,
+) -> StdResult<()> {
     CHECK_POINTS.save(storage, delegator, checkpoints)?;
     Ok(())
 }
@@ -70,8 +71,13 @@ pub fn store_checkpoints(storage: &mut dyn Storage, delegator: Addr, checkpoints
 //     CHECK_POINTS.may_load(storage, delegator)?.ok_or_else(|| StdError::generic_err("Checkpoints not found"))
 // }
 
-pub fn read_checkpoints_default(storage: &dyn Storage, delegator: Addr) -> StdResult<Vec<Checkpoint>> {
-    Ok(CHECK_POINTS.may_load(storage, delegator)?.unwrap_or_default())
+pub fn read_checkpoints_default(
+    storage: &dyn Storage,
+    delegator: Addr,
+) -> StdResult<Vec<Checkpoint>> {
+    Ok(CHECK_POINTS
+        .may_load(storage, delegator)?
+        .unwrap_or_default())
 }
 
 // pub fn store_vote_info(storage: &mut dyn Storage, vote_info: &VoteInfo) -> StdResult<()> {
@@ -83,11 +89,11 @@ pub fn read_checkpoints_default(storage: &dyn Storage, delegator: Addr) -> StdRe
 //     VOTE_INFO.may_load(storage)?.ok_or_else(|| StdError::generic_err("Vote info not found"))
 // }
 
-pub fn read_vote_info_default(storage: &dyn Storage) -> StdResult<VoteInfo> {
-    Ok(VOTE_INFO.may_load(storage)?.unwrap_or(VoteInfo {
-        total_supply_checkpoints: Vec::new()
-    }))
-}
+// pub fn read_vote_info_default(storage: &dyn Storage) -> StdResult<VoteInfo> {
+//     Ok(VOTE_INFO.may_load(storage)?.unwrap_or(VoteInfo {
+//         total_supply_checkpoints: Vec::new()
+//     }))
+// }
 
 pub fn store_vote_config(storage: &mut dyn Storage, vote_config: &VoteConfig) -> StdResult<()> {
     VOTE_CONFIG.save(storage, vote_config)?;
@@ -95,7 +101,9 @@ pub fn store_vote_config(storage: &mut dyn Storage, vote_config: &VoteConfig) ->
 }
 
 pub fn read_vote_config(storage: &dyn Storage) -> StdResult<VoteConfig> {
-    VOTE_CONFIG.may_load(storage)?.ok_or_else(|| StdError::generic_err("Vote config not found"))
+    VOTE_CONFIG
+        .may_load(storage)?
+        .ok_or_else(|| StdError::generic_err("Vote config not found"))
 }
 
 pub fn store_minters(storage: &mut dyn Storage, minter: Addr, is_minter: &bool) -> StdResult<()> {
@@ -110,5 +118,3 @@ pub fn store_minters(storage: &mut dyn Storage, minter: Addr, is_minter: &bool) 
 pub fn is_minter(storage: &dyn Storage, minter: Addr) -> StdResult<bool> {
     Ok(MINTERS.may_load(storage, minter)?.unwrap_or(false))
 }
-
-

--- a/contracts/ve_seilor/src/ve_querier.rs
+++ b/contracts/ve_seilor/src/ve_querier.rs
@@ -1,8 +1,7 @@
-use std::ops::{Add, Div, Sub};
+use crate::msg::{GetPastVotesResponse, GetVotesResponse, NumCheckpointsResponse};
+use crate::state::{read_checkpoints_default, Checkpoint};
 use cosmwasm_std::{Addr, Deps, Env, Isqrt, StdError, StdResult};
-use crate::msg::{GetPastTotalSupplyResponse, GetPastVotesResponse, GetVotesResponse, NumCheckpointsResponse};
-use crate::state::{Checkpoint, read_checkpoints_default, read_vote_info_default};
-
+use std::ops::{Add, Div, Sub};
 
 /**
  * @dev Get the `pos`-th checkpoint for `account`.
@@ -21,9 +20,10 @@ pub fn checkpoints(deps: Deps, account: Addr, pos: u32) -> StdResult<Checkpoint>
  */
 pub fn num_checkpoints(deps: Deps, account: Addr) -> StdResult<NumCheckpointsResponse> {
     let check_points = read_checkpoints_default(deps.storage, account)?;
-    Ok(NumCheckpointsResponse { num: check_points.len() })
+    Ok(NumCheckpointsResponse {
+        num: check_points.len(),
+    })
 }
-
 
 // /**
 //  * @dev Get the address `account` is currently delegating to.
@@ -46,7 +46,6 @@ pub fn get_votes(deps: Deps, account: Addr) -> StdResult<GetVotesResponse> {
     Ok(GetVotesResponse { votes })
 }
 
-
 /**
  * @dev Retrieve the number of votes for `account` at the end of `blockNumber`.
  *
@@ -54,7 +53,12 @@ pub fn get_votes(deps: Deps, account: Addr) -> StdResult<GetVotesResponse> {
  *
  * - `blockNumber` must have been already mined
  */
-pub fn get_past_votes(deps: Deps, env: Env, account: Addr, block_number: u64) -> StdResult<GetPastVotesResponse> {
+pub fn get_past_votes(
+    deps: Deps,
+    env: Env,
+    account: Addr,
+    block_number: u64,
+) -> StdResult<GetPastVotesResponse> {
     if block_number >= env.block.height {
         return Err(StdError::generic_err("Block not yet mined"));
     }
@@ -62,7 +66,6 @@ pub fn get_past_votes(deps: Deps, env: Env, account: Addr, block_number: u64) ->
     let votes = _check_points_lookup(check_points, block_number);
     Ok(GetPastVotesResponse { votes })
 }
-
 
 /**
  * @dev Retrieve the `totalSupply` at the end of `blockNumber`. Note, this value is the sum of all balances.
@@ -72,14 +75,14 @@ pub fn get_past_votes(deps: Deps, env: Env, account: Addr, block_number: u64) ->
  *
  * - `blockNumber` must have been already mined
  */
-pub fn get_past_total_supply(deps: Deps, env: Env, block_number: u64) -> StdResult<GetPastTotalSupplyResponse> {
-    if block_number >= env.block.height {
-        return Err(StdError::generic_err("Block not yet mined"));
-    }
-    let vote_info = read_vote_info_default(deps.storage)?;
-    let total_supply = _check_points_lookup(vote_info.total_supply_checkpoints, block_number);
-    Ok(GetPastTotalSupplyResponse { total_supply })
-}
+// pub fn get_past_total_supply(deps: Deps, env: Env, block_number: u64) -> StdResult<GetPastTotalSupplyResponse> {
+//     if block_number >= env.block.height {
+//         return Err(StdError::generic_err("Block not yet mined"));
+//     }
+//     let vote_info = read_vote_info_default(deps.storage)?;
+//     let total_supply = _check_points_lookup(vote_info.total_supply_checkpoints, block_number);
+//     Ok(GetPastTotalSupplyResponse { total_supply })
+// }
 
 /**
  * @dev Lookup a value in a list of (sorted) checkpoints.
@@ -123,20 +126,31 @@ fn _check_points_lookup(check_points: Vec<Checkpoint>, block_number: u64) -> u12
     check_points[high.sub(1usize)].votes
 }
 
-
 #[cfg(test)]
 mod tests {
-    use std::ops::Sub;
     use super::*;
+    use std::ops::Sub;
 
     #[test]
     fn test_check_points_lookup() {
         // Positive test case
         let check_points = vec![
-            Checkpoint { from_block: 0, votes: 100 },
-            Checkpoint { from_block: 100, votes: 200 },
-            Checkpoint { from_block: 200, votes: 300 },
-            Checkpoint { from_block: 300, votes: 400 },
+            Checkpoint {
+                from_block: 0,
+                votes: 100,
+            },
+            Checkpoint {
+                from_block: 100,
+                votes: 200,
+            },
+            Checkpoint {
+                from_block: 200,
+                votes: 300,
+            },
+            Checkpoint {
+                from_block: 300,
+                votes: 400,
+            },
         ];
         let pos = check_points.len();
         let s: usize = 1usize;


### PR DESCRIPTION
Fixed issues 3 (remove method)

The following messages are included in the code but will not be used in the logic of their contracts:

krp-token-contracts/ve_seilor: QueryMsg::GetPastTotalSupply