### PR TITLE
Unchecked amount of periods

### DIFF
--- a/contracts/dispatcher/src/contract.rs
+++ b/contracts/dispatcher/src/contract.rs
@@ -35,6 +35,10 @@ pub fn instantiate(
             "duration_per_period must be greater than 0",
         ));
     }
+    // verify that periods is greater than 0
+    if msg.periods <= 0 {
+        return Err(StdError::generic_err("periods must be greater than 0"));
+    }
     let global_config = GlobalConfig {
         gov,
         claim_token: msg.claim_token,


### PR DESCRIPTION
Fixed issues 9
The instantiate function in dispatcher contract do not verify that duration_per_period is greater than 0. If it is mistakenly set to a 0, the claiming operation will always panic because of a division by 0.