### PR TITLE
Lock amount in global state is not validated when claiming

### DIFF
--- a/contracts/dispatcher/src/error.rs
+++ b/contracts/dispatcher/src/error.rs
@@ -62,4 +62,7 @@ pub enum ContractError {
     UserClaimUnlockAmountTooLarge(Addr),
     #[error("UserClaimAmountIsZero:{0}")]
     UserClaimAmountIsZero(Addr),
+
+    #[error("Global Claim Lock Amount Too Large")]
+    GlobalClaimLockAmountTooLarge {},
 }

--- a/contracts/dispatcher/src/handler.rs
+++ b/contracts/dispatcher/src/handler.rs
@@ -179,6 +179,10 @@ pub fn user_claim(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response
         }
     }
 
+    // validate that global_state.total_user_claimed_lock_amount <= global_state.total_user_lock_amount
+    if global_state.total_user_claimed_lock_amount > global_state.total_user_lock_amount {
+        return Err(ContractError::GlobalClaimLockAmountTooLarge {});
+    }
     // check claimable amount is not zero
     if claimable_amount == Uint256::zero() {
         return Err(ContractError::UserClaimAmountIsZero(sender.clone()));


### PR DESCRIPTION
Fixed issues 10
The instantiate function in dispatcher contract do not verify that duration_per_period is greater than 0. If it is mistakenly set to a 0, the claiming operation will always panic because of a division by 0.