### PR TITLE
Ownership can be transferred without confirmation

### DIFF
--- a/contracts/boost/src/contract.rs
+++ b/contracts/boost/src/contract.rs
@@ -1,4 +1,4 @@
-use crate::handler::{add_lock_setting, change_gov, set_lock_status};
+use crate::handler::{accept_gov, add_lock_setting, set_gov, set_lock_status};
 use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 use crate::querier::{get_boost_config, get_unlock_time, get_user_boost, get_user_lock_status};
 use crate::state::{store_boost_config, BoostConfig};
@@ -25,6 +25,7 @@ pub fn instantiate(
     let config = BoostConfig {
         gov: gov,
         ve_seilor_lock_settings: msg.ve_seilor_lock_settings,
+        new_gov: None,
     };
 
     store_boost_config(deps.storage, &config)?;
@@ -41,7 +42,8 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> S
             duration,
             mining_boost,
         } => add_lock_setting(deps, info, duration, mining_boost),
-        ExecuteMsg::ChangeGov { gov } => change_gov(deps, info, gov),
+        ExecuteMsg::SetGov { gov } => set_gov(deps, info, gov),
+        ExecuteMsg::AcceptGov {} => accept_gov(deps, info),
         ExecuteMsg::SetLockStatus { index } => {
             let _index = index as usize;
             set_lock_status(deps, env, info, _index)

--- a/contracts/boost/src/msg.rs
+++ b/contracts/boost/src/msg.rs
@@ -1,6 +1,6 @@
+use crate::state::VeSeilorLockSetting;
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Uint128};
-use crate::state::VeSeilorLockSetting;
 
 #[cw_serde]
 pub struct LockStatusResponse {
@@ -21,9 +21,10 @@ pub enum ExecuteMsg {
         duration: Uint128,
         mining_boost: Uint128,
     },
-    ChangeGov {
+    SetGov {
         gov: Addr,
     },
+    AcceptGov {},
     SetLockStatus {
         index: u32,
     },
@@ -33,13 +34,9 @@ pub enum ExecuteMsg {
 #[derive(QueryResponses)]
 pub enum QueryMsg {
     #[returns(GetUnlockTimeResponse)]
-    GetUnlockTime {
-        user: Addr,
-    },
+    GetUnlockTime { user: Addr },
     #[returns(LockStatusResponse)]
-    GetUserLockStatus {
-        user: Addr,
-    },
+    GetUserLockStatus { user: Addr },
     #[returns(GetUserBoostResponse)]
     GetUserBoost {
         user: Addr,

--- a/contracts/boost/src/state.rs
+++ b/contracts/boost/src/state.rs
@@ -3,7 +3,6 @@ use cw_storage_plus::{Item, Map};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-
 // Define a struct for the lock settings
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct VeSeilorLockSetting {
@@ -23,6 +22,7 @@ pub struct LockStatus {
 pub struct BoostConfig {
     pub gov: Addr,
     pub ve_seilor_lock_settings: Vec<VeSeilorLockSetting>,
+    pub new_gov: Option<Addr>,
 }
 
 const BOOST_CONFIG: Item<BoostConfig> = Item::new("boost_config");
@@ -38,7 +38,11 @@ pub fn read_boost_config(storage: &dyn Storage) -> StdResult<BoostConfig> {
     BOOST_CONFIG.load(storage)
 }
 
-pub fn store_user_lock_status(storage: &mut dyn Storage, user: Addr, lock_status: &LockStatus) -> StdResult<()> {
+pub fn store_user_lock_status(
+    storage: &mut dyn Storage,
+    user: Addr,
+    lock_status: &LockStatus,
+) -> StdResult<()> {
     USER_LOCK_STATUS.save(storage, user, lock_status)?;
     Ok(())
 }
@@ -50,6 +54,3 @@ pub fn read_user_lock_status(storage: &dyn Storage, user: Addr) -> StdResult<Loc
         mining_boost: Uint128::zero(),
     }))
 }
-
-
-

--- a/contracts/dispatcher/src/contract.rs
+++ b/contracts/dispatcher/src/contract.rs
@@ -1,5 +1,5 @@
 use crate::error::ContractError;
-use crate::handler::{add_users, update_config, user_claim};
+use crate::handler::{accept_gov, add_users, set_gov, update_config, user_claim};
 use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 use crate::querier::{query_global_infos, query_user_info, query_user_infos};
 use crate::state::{store_global_config, store_global_state, GlobalConfig, GlobalState};
@@ -46,6 +46,7 @@ pub fn instantiate(
         start_lock_period_time: msg.start_lock_period_time,
         duration_per_period: msg.duration_per_period,
         periods: msg.periods,
+        new_gov: None,
     };
 
     let global_state = GlobalState {
@@ -71,6 +72,8 @@ pub fn execute(
         ExecuteMsg::UpdateConfig(msg) => update_config(deps, env, info, msg),
         ExecuteMsg::AddUser(msg) => add_users(deps, info, msg),
         ExecuteMsg::UserClaim {} => user_claim(deps, env, info),
+        ExecuteMsg::SetGov { gov } => set_gov(deps, info, gov),
+        ExecuteMsg::AcceptGov {} => accept_gov(deps, info),
     }
 }
 

--- a/contracts/dispatcher/src/error.rs
+++ b/contracts/dispatcher/src/error.rs
@@ -11,6 +11,8 @@ pub enum ContractError {
 
     #[error("Unauthorized")]
     Unauthorized {},
+    #[error("No New Gov")]
+    NoNewGov {},
 
     #[error("ConversionOverflow")]
     ConversionOverflow(#[from] ConversionOverflowError),

--- a/contracts/dispatcher/src/msg.rs
+++ b/contracts/dispatcher/src/msg.rs
@@ -4,7 +4,6 @@ use cosmwasm_std::{Addr, Uint256};
 
 #[cw_serde]
 pub struct UpdateGlobalConfigMsg {
-    pub gov: Option<Addr>,
     pub claim_token: Option<Addr>,
     pub start_lock_period_time: Option<u64>,
     pub total_lock_amount: Option<Uint256>,
@@ -32,6 +31,8 @@ pub enum ExecuteMsg {
     UpdateConfig(UpdateGlobalConfigMsg),
     AddUser(Vec<AddUserMsg>),
     UserClaim {},
+    SetGov { gov: Addr },
+    AcceptGov {},
 }
 
 #[cw_serde]

--- a/contracts/dispatcher/src/state.rs
+++ b/contracts/dispatcher/src/state.rs
@@ -13,6 +13,7 @@ pub struct GlobalConfig {
     pub start_lock_period_time: u64,
     pub duration_per_period: u64,
     pub periods: u64,
+    pub new_gov: Option<Addr>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/contracts/dispatcher/src/testing/tests.rs
+++ b/contracts/dispatcher/src/testing/tests.rs
@@ -1,6 +1,7 @@
-use crate::handler::{add_users, update_config};
+use crate::handler::{accept_gov, add_users, set_gov, update_config};
 use crate::msg::{AddUserMsg, UpdateGlobalConfigMsg};
 use crate::testing::mock_fn::{mock_instantiate, mock_instantiate_msg, CLAIM_TOKEN};
+use cosmwasm_std::testing::mock_info;
 use cosmwasm_std::{Addr, Uint256};
 
 #[test]
@@ -31,7 +32,6 @@ fn test_update_config() {
         env.clone(),
         info.clone(),
         UpdateGlobalConfigMsg {
-            gov: Option::from(Addr::unchecked("new_gov".to_string())),
             claim_token: Option::from(Addr::unchecked("new_claim_token".to_string())),
             start_lock_period_time: Option::from(11111),
             total_lock_amount: Option::from(Uint256::from(11113u128)),
@@ -44,7 +44,6 @@ fn test_update_config() {
         env.clone(),
         info.clone(),
         UpdateGlobalConfigMsg {
-            gov: Option::from(Addr::unchecked("new_gov".to_string())),
             claim_token: Option::from(Addr::unchecked("new_claim_token".to_string())),
             start_lock_period_time: Option::from(11111),
             total_lock_amount: Option::from(Uint256::from(11115u128)),
@@ -53,10 +52,10 @@ fn test_update_config() {
     assert!(res.is_ok());
 
     let new_config = crate::querier::query_global_infos(deps.as_ref()).unwrap();
-    assert_eq!(
-        new_config.config.gov,
-        Addr::unchecked("new_gov".to_string())
-    );
+    // assert_eq!(
+    //     new_config.config.gov,
+    //     Addr::unchecked("new_gov".to_string())
+    // );
     assert_eq!(
         new_config.config.claim_token,
         Addr::unchecked("new_claim_token".to_string())
@@ -65,5 +64,32 @@ fn test_update_config() {
     assert_eq!(
         new_config.config.total_lock_amount,
         Uint256::from(11115u128)
+    );
+
+    //change gov
+    let res = set_gov(
+        deps.as_mut(),
+        info.clone(),
+        Addr::unchecked("new_gov".to_string()),
+    );
+    assert!(res.is_ok());
+    let new_config = crate::querier::query_global_infos(deps.as_ref()).unwrap();
+    assert_eq!(
+        new_config.config.new_gov.unwrap(),
+        Addr::unchecked("new_gov".to_string())
+    );
+    assert_eq!(
+        new_config.config.gov,
+        Addr::unchecked("creator".to_string())
+    );
+
+    let info = mock_info("new_gov", &[]);
+    let res = accept_gov(deps.as_mut(), info.clone());
+    assert!(res.is_ok());
+    let new_config = crate::querier::query_global_infos(deps.as_ref()).unwrap();
+    assert_eq!(new_config.config.new_gov, None);
+    assert_eq!(
+        new_config.config.gov,
+        Addr::unchecked("new_gov".to_string())
     );
 }

--- a/contracts/distribute/src/contract.rs
+++ b/contracts/distribute/src/contract.rs
@@ -1,5 +1,7 @@
 use crate::error::ContractError;
-use crate::handler::{add_rule_config, claim, update_config, update_rule_config};
+use crate::handler::{
+    accept_gov, add_rule_config, claim, set_gov, update_config, update_rule_config,
+};
 use crate::helper::BASE_RATE_12;
 use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 use crate::querier::{query_claimable_info, query_config, query_rule_info};
@@ -64,6 +66,7 @@ pub fn instantiate(
         total_amount: msg.total_amount,
         distribute_token: msg.distribute_token,
         rules_total_amount: rule_total_amount,
+        new_gov: None,
     };
 
     if distribute_config.total_amount < rule_total_amount {
@@ -98,10 +101,9 @@ pub fn execute(
 ) -> Result<Response, ContractError> {
     match msg {
         ExecuteMsg::Claim { rule_type, msg } => claim(deps, env, info, rule_type, msg),
-        ExecuteMsg::UpdateConfig {
-            gov,
-            distribute_token,
-        } => update_config(deps, info, gov, distribute_token),
+        ExecuteMsg::UpdateConfig { distribute_token } => {
+            update_config(deps, info, distribute_token)
+        }
         ExecuteMsg::UpdateRuleConfig { update_rule_msg } => {
             update_rule_config(deps, info, update_rule_msg)
         }
@@ -109,6 +111,8 @@ pub fn execute(
             rule_type,
             rule_msg,
         } => add_rule_config(deps, info, rule_type, rule_msg),
+        ExecuteMsg::SetGov { gov } => set_gov(deps, info, gov),
+        ExecuteMsg::AcceptGov {} => accept_gov(deps, info),
     }
 }
 

--- a/contracts/distribute/src/error.rs
+++ b/contracts/distribute/src/error.rs
@@ -20,4 +20,7 @@ pub enum ContractError {
 
     #[error("AmountClaimOverTotal,claimed_amount:{0},rule_total_amount:{1}")]
     AmountClaimOverTotal(u128, u128),
+
+    #[error("No New Gov")]
+    NoNewGov {},
 }

--- a/contracts/distribute/src/msg.rs
+++ b/contracts/distribute/src/msg.rs
@@ -59,7 +59,6 @@ pub enum ExecuteMsg {
         msg: Option<Binary>,
     },
     UpdateConfig {
-        gov: Option<Addr>,
         distribute_token: Option<Addr>,
     },
     UpdateRuleConfig {
@@ -69,6 +68,10 @@ pub enum ExecuteMsg {
         rule_type: String,
         rule_msg: RuleConfigMsg,
     },
+    SetGov {
+        gov: Addr,
+    },
+    AcceptGov {},
 }
 
 #[cw_serde]

--- a/contracts/distribute/src/state.rs
+++ b/contracts/distribute/src/state.rs
@@ -9,6 +9,7 @@ pub struct DistributeConfig {
     pub total_amount: u128,
     pub distribute_token: Addr,
     pub rules_total_amount: u128,
+    pub new_gov: Option<Addr>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/contracts/distribute/src/testing/mock_third_fn.rs
+++ b/contracts/distribute/src/testing/mock_third_fn.rs
@@ -1,3 +1,5 @@
+use cw20_base::msg::InstantiateMarketingInfo;
+
 pub fn mock_seilor_instantiate_msg() -> seilor::msg::InstantiateMsg {
     let max_supply = 1000000000000000u128;
     let cw20_init_msg = cw20_base::msg::InstantiateMsg {
@@ -6,7 +8,12 @@ pub fn mock_seilor_instantiate_msg() -> seilor::msg::InstantiateMsg {
         decimals: 6,
         initial_balances: vec![],
         mint: None,
-        marketing: None,
+        marketing: Some(InstantiateMarketingInfo {
+            project: None,
+            description: None,
+            marketing: Some("aass".to_string()),
+            logo: None,
+        }),
     };
     let msg = seilor::msg::InstantiateMsg {
         cw20_init_msg,

--- a/contracts/distribute/src/testing/tests.rs
+++ b/contracts/distribute/src/testing/tests.rs
@@ -29,24 +29,19 @@ fn test_update_config() {
     let (mut deps, _, info, res) = mock_instantiate(msg.clone());
     assert!(res.is_ok());
 
-    let new_gov = Some(Addr::unchecked("new_gov"));
+    // let new_gov = Some(Addr::unchecked("new_gov"));
     let new_distribute_token = Some(Addr::unchecked("new_distribute_token"));
-    let res = update_config(
-        deps.as_mut(),
-        info,
-        new_gov.clone(),
-        new_distribute_token.clone(),
-    );
+    let res = update_config(deps.as_mut(), info, new_distribute_token.clone());
     assert!(res.is_ok());
     let config = query_config(deps.as_ref()).unwrap();
-    assert_eq!(config.gov, Addr::unchecked("new_gov"));
+    // assert_eq!(config.gov, Addr::unchecked("new_gov"));
     assert_eq!(
         config.distribute_token,
         Addr::unchecked("new_distribute_token")
     );
 
     let other_info = mock_info("other", &[]);
-    let res = update_config(deps.as_mut(), other_info, new_gov, new_distribute_token);
+    let res = update_config(deps.as_mut(), other_info, new_distribute_token);
     assert!(res.is_err());
     assert_eq!(res.err().unwrap(), ContractError::Unauthorized {});
 }

--- a/contracts/fund/src/contract.rs
+++ b/contracts/fund/src/contract.rs
@@ -1,6 +1,6 @@
 use crate::handler::{
-    get_reward, notify_reward_amount, re_stake, receive_cw20, refresh_reward, unstake,
-    update_fund_config, withdraw,
+    accept_gov, get_reward, notify_reward_amount, re_stake, receive_cw20, refresh_reward, set_gov,
+    unstake, update_fund_config, withdraw,
 };
 use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 use crate::querier::{
@@ -42,6 +42,7 @@ pub fn instantiate(
         reward_per_token_stored: Uint128::zero(),
         exit_cycle: msg.exit_cycle,
         claim_able_time: msg.claim_able_time,
+        new_gov: None,
     };
 
     store_fund_config(deps.storage, &config)?;
@@ -65,6 +66,8 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> S
         ExecuteMsg::ReStake { .. } => re_stake(deps, env, info),
         ExecuteMsg::GetReward { .. } => get_reward(deps, info),
         ExecuteMsg::NotifyRewardAmount { .. } => notify_reward_amount(deps, info),
+        ExecuteMsg::SetGov { gov } => set_gov(deps, info, gov),
+        ExecuteMsg::AcceptGov {} => accept_gov(deps, info),
     }
 }
 

--- a/contracts/fund/src/msg.rs
+++ b/contracts/fund/src/msg.rs
@@ -4,7 +4,6 @@ use cw20::Cw20ReceiveMsg;
 
 #[cw_serde]
 pub struct UpdateConfigMsg {
-    pub gov: Option<Addr>,
     pub ve_seilor_addr: Option<Addr>,
     pub seilor_addr: Option<Addr>,
     pub kusd_denom: Option<String>,
@@ -42,6 +41,10 @@ pub enum ExecuteMsg {
     ReStake {},
     GetReward {},
     NotifyRewardAmount {},
+    SetGov {
+        gov: Addr,
+    },
+    AcceptGov {},
 }
 
 #[cw_serde]
@@ -129,6 +132,7 @@ pub struct FundConfigResponse {
     pub exit_cycle: Uint64,
     // uint256 public claimAbleTime;
     pub claim_able_time: Uint64,
+    pub new_gov: Option<Addr>,
 }
 
 #[cw_serde]

--- a/contracts/fund/src/querier.rs
+++ b/contracts/fund/src/querier.rs
@@ -1,7 +1,7 @@
 use crate::helper::{BASE_RATE_12, BASE_RATE_6};
 use crate::msg::{
-    EarnedResponse, GetClaimAbleSeilorResponse, GetClaimAbleKusdResponse,
-    GetReservedSeilorForVestingResponse, FundConfigResponse, UserLastWithdrawTimeResponse,
+    EarnedResponse, FundConfigResponse, GetClaimAbleKusdResponse, GetClaimAbleSeilorResponse,
+    GetReservedSeilorForVestingResponse, UserLastWithdrawTimeResponse,
     UserRewardPerTokenPaidResponse, UserRewardsResponse, UserTime2fullRedemptionResponse,
     UserUnstakeRateResponse,
 };
@@ -29,6 +29,7 @@ pub fn fund_config(deps: Deps) -> StdResult<FundConfigResponse> {
         reward_per_token_stored: config.reward_per_token_stored,
         exit_cycle: config.exit_cycle,
         claim_able_time: config.claim_able_time,
+        new_gov: config.new_gov,
     })
 }
 
@@ -55,7 +56,11 @@ pub fn staked_of(deps: Deps, staker: Addr) -> StdResult<Uint128> {
     Ok(res.balance)
 }
 
-pub fn get_claim_able_seilor(deps: Deps, env: Env, user: Addr) -> StdResult<GetClaimAbleSeilorResponse> {
+pub fn get_claim_able_seilor(
+    deps: Deps,
+    env: Env,
+    user: Addr,
+) -> StdResult<GetClaimAbleSeilorResponse> {
     let time2full_redemption_user = read_time2full_redemption(deps.storage, user.clone());
     let last_withdraw_time_user = read_last_withdraw_time(deps.storage, user.clone());
     let unstake_rate_user = read_unstake_rate(deps.storage, user.clone());

--- a/contracts/fund/src/state.rs
+++ b/contracts/fund/src/state.rs
@@ -18,6 +18,7 @@ pub struct FundConfig {
     pub exit_cycle: Uint64,
     // uint256 public claimAbleTime;
     pub claim_able_time: Uint64,
+    pub new_gov: Option<Addr>,
 }
 
 const FUND_CONFIG: Item<FundConfig> = Item::new("fund_config");
@@ -35,10 +36,7 @@ const UNSTAKE_RATE: Map<Addr, Uint256> = Map::new("unstake_rate");
 // mapping(address => uint) public lastWithdrawTime;
 const LAST_WITHDRAW_TIME: Map<Addr, Uint64> = Map::new("last_withdraw_time");
 
-pub fn store_fund_config(
-    storage: &mut dyn Storage,
-    fund_config: &FundConfig,
-) -> StdResult<()> {
+pub fn store_fund_config(storage: &mut dyn Storage, fund_config: &FundConfig) -> StdResult<()> {
     FUND_CONFIG.save(storage, fund_config)?;
     Ok(())
 }

--- a/contracts/fund/src/testing/mock_third_fn.rs
+++ b/contracts/fund/src/testing/mock_third_fn.rs
@@ -1,6 +1,7 @@
+use crate::testing::mock_fn::CREATOR;
 use cosmwasm_std::Uint128;
 use cw20::Cw20Coin;
-use crate::testing::mock_fn::CREATOR;
+use cw20_base::msg::InstantiateMarketingInfo;
 
 pub fn mock_seilor_instantiate_msg() -> seilor::msg::InstantiateMsg {
     let max_supply = 1000000000000000u128;
@@ -8,14 +9,17 @@ pub fn mock_seilor_instantiate_msg() -> seilor::msg::InstantiateMsg {
         name: "seilor dev".to_string(),
         symbol: "seilor".to_string(),
         decimals: 6,
-        initial_balances: vec![
-            Cw20Coin {
-                address: CREATOR.to_string(),
-                amount: Uint128::from(200000000000000u128),
-            },
-        ],
+        initial_balances: vec![Cw20Coin {
+            address: CREATOR.to_string(),
+            amount: Uint128::from(200000000000000u128),
+        }],
         mint: None,
-        marketing: None,
+        marketing: Some(InstantiateMarketingInfo {
+            project: None,
+            description: None,
+            marketing: Some("aass".to_string()),
+            logo: None,
+        }),
     };
     let msg = seilor::msg::InstantiateMsg {
         cw20_init_msg,
@@ -32,7 +36,12 @@ pub fn mock_ve_seilor_instantiate_msg() -> ve_seilor::msg::InstantiateMsg {
         decimals: 6u8,
         initial_balances: vec![],
         mint: None,
-        marketing: None,
+        marketing: Some(InstantiateMarketingInfo {
+            project: None,
+            description: None,
+            marketing: Some("aass".to_string()),
+            logo: None,
+        }),
     };
     let msg = ve_seilor::msg::InstantiateMsg {
         max_supply: 60500000000000u128,

--- a/contracts/fund/src/testing/tests.rs
+++ b/contracts/fund/src/testing/tests.rs
@@ -1,10 +1,12 @@
-use cosmwasm_std::{Addr, Uint128, Uint64};
-use cosmwasm_std::testing::mock_info;
 use crate::handler::update_fund_config;
 use crate::msg::{FundConfigResponse, UpdateConfigMsg};
 use crate::querier::fund_config;
-use crate::state::{read_fund_config};
-use crate::testing::mock_fn::{CREATOR, KUSD_DENOM, KUSD_REWARD_ADDR, mock_instantiate, mock_instantiate_msg};
+use crate::state::read_fund_config;
+use crate::testing::mock_fn::{
+    mock_instantiate, mock_instantiate_msg, CREATOR, KUSD_DENOM, KUSD_REWARD_ADDR,
+};
+use cosmwasm_std::testing::mock_info;
+use cosmwasm_std::{Addr, Uint128, Uint64};
 
 #[test]
 fn test_instantiate() {
@@ -12,26 +14,31 @@ fn test_instantiate() {
     let ve_seilor_addr = Addr::unchecked("ve_seilor".to_string());
     let msg = mock_instantiate_msg(seilor_addr.clone(), ve_seilor_addr.clone());
     let (deps, _env, _info, res) = mock_instantiate(msg);
-    assert_eq!(res.attributes, vec![
-        ("action", "instantiate"),
-        ("owner", "creator"),
-    ]);
+    assert_eq!(
+        res.attributes,
+        vec![("action", "instantiate"), ("owner", "creator"),]
+    );
 
     let config = read_fund_config(deps.as_ref().storage).unwrap();
-    assert_eq!(config.ve_seilor_addr.to_string(), ve_seilor_addr.to_string());
+    assert_eq!(
+        config.ve_seilor_addr.to_string(),
+        ve_seilor_addr.to_string()
+    );
     assert_eq!(config.seilor_addr.to_string(), seilor_addr.to_string());
     assert_eq!(config.kusd_denom, KUSD_DENOM.to_string());
-    assert_eq!(config.kusd_reward_addr.to_string(), KUSD_REWARD_ADDR.to_string());
+    assert_eq!(
+        config.kusd_reward_addr.to_string(),
+        KUSD_REWARD_ADDR.to_string()
+    );
     assert_eq!(config.kusd_reward_total_amount, Uint128::zero());
     assert_eq!(config.kusd_reward_total_paid_amount, Uint128::zero());
     assert_eq!(config.reward_per_token_stored, Uint128::zero());
     assert_eq!(config.exit_cycle, Uint64::from(2592000u64));
     assert_eq!(config.claim_able_time, Uint64::from(1687190400u64));
-
 }
 
 #[test]
-fn test_update_fund_config(){
+fn test_update_fund_config() {
     let seilor_addr = Addr::unchecked("seilor".to_string());
     let ve_seilor_addr = Addr::unchecked("ve_seilor".to_string());
     let msg = mock_instantiate_msg(seilor_addr.clone(), ve_seilor_addr.clone());
@@ -39,7 +46,6 @@ fn test_update_fund_config(){
 
     // Update the config
     let update_msg = UpdateConfigMsg {
-        gov: Option::from(Addr::unchecked("new_gov")),
         ve_seilor_addr: Option::from(Addr::unchecked("new_ve_seilor")),
         seilor_addr: Option::from(Addr::unchecked("new_seilor")),
         kusd_denom: Option::from("new_kusd".to_string()),
@@ -53,16 +59,20 @@ fn test_update_fund_config(){
     let res = update_fund_config(deps.as_mut(), info.clone(), update_msg.clone());
     assert!(res.is_ok());
     let config: FundConfigResponse = fund_config(deps.as_ref()).unwrap();
-    assert_eq!(config, FundConfigResponse {
-        gov: Option::from(update_msg.gov.unwrap()).unwrap(),
-        ve_seilor_addr: Option::from(update_msg.ve_seilor_addr.unwrap()).unwrap(),
-        seilor_addr: Option::from(update_msg.seilor_addr.unwrap()).unwrap(),
-        kusd_denom: Option::from(update_msg.kusd_denom.unwrap()).unwrap(),
-        kusd_reward_addr: Option::from(update_msg.kusd_reward_addr.unwrap()).unwrap(),
-        kusd_reward_total_amount: Uint128::zero(),
-        kusd_reward_total_paid_amount: Uint128::zero(),
-        reward_per_token_stored: Uint128::zero(),
-        exit_cycle: Uint64::from(2592000u64),
-        claim_able_time: Option::from(update_msg.claim_able_time.unwrap()).unwrap(),
-    });
+    assert_eq!(
+        config,
+        FundConfigResponse {
+            gov: Addr::unchecked(CREATOR.to_string()),
+            ve_seilor_addr: Option::from(update_msg.ve_seilor_addr.unwrap()).unwrap(),
+            seilor_addr: Option::from(update_msg.seilor_addr.unwrap()).unwrap(),
+            kusd_denom: Option::from(update_msg.kusd_denom.unwrap()).unwrap(),
+            kusd_reward_addr: Option::from(update_msg.kusd_reward_addr.unwrap()).unwrap(),
+            kusd_reward_total_amount: Uint128::zero(),
+            kusd_reward_total_paid_amount: Uint128::zero(),
+            reward_per_token_stored: Uint128::zero(),
+            exit_cycle: Uint64::from(2592000u64),
+            claim_able_time: Option::from(update_msg.claim_able_time.unwrap()).unwrap(),
+            new_gov: None,
+        }
+    );
 }

--- a/contracts/keeper/src/contract.rs
+++ b/contracts/keeper/src/contract.rs
@@ -1,5 +1,7 @@
 use crate::error::ContractError;
-use crate::handler::{distribute_rewards, optional_addr_validate, update_config};
+use crate::handler::{
+    accept_ownership, distribute_rewards, optional_addr_validate, set_owner, update_config,
+};
 use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 
 use crate::querier::{query_config, query_state};
@@ -35,6 +37,7 @@ pub fn instantiate(
         threshold: msg.threshold,
         rewards_contract: api.addr_canonicalize(&msg.rewards_contract)?,
         rewards_denom: msg.rewards_denom,
+        new_owner: None,
     };
     store_config(deps.storage, &config)?;
 
@@ -60,7 +63,6 @@ pub fn execute(
 ) -> Result<Response, ContractError> {
     match msg {
         ExecuteMsg::UpdateConfig {
-            owner,
             threshold,
             rewards_contract,
             rewards_denom,
@@ -69,13 +71,14 @@ pub fn execute(
             update_config(
                 deps,
                 info,
-                optional_addr_validate(api, owner)?,
                 threshold,
                 optional_addr_validate(api, rewards_contract)?,
                 rewards_denom,
             )
         }
         ExecuteMsg::Distribute {} => distribute_rewards(deps, env),
+        ExecuteMsg::SetOwner { owner } => set_owner(deps, info, owner),
+        ExecuteMsg::AcceptOwnership {} => accept_ownership(deps, env, info),
     }
 }
 

--- a/contracts/keeper/src/error.rs
+++ b/contracts/keeper/src/error.rs
@@ -12,11 +12,11 @@ pub enum ContractError {
     #[error("Distribute contract unauthorized calling function:{0}, params:{1}")]
     Unauthorized(String, String),
 
-    
     #[error("Distribute rewards less than threshold: {0}")]
     DistributeRewardsLessThanThreshold(Uint128),
 
     #[error("Invalid input")]
     InvalidInput {},
-
+    #[error("No new owner")]
+    NoNewOwner {},
 }

--- a/contracts/keeper/src/handler.rs
+++ b/contracts/keeper/src/handler.rs
@@ -3,8 +3,8 @@ use crate::querier::query_balance;
 use crate::state::{read_config, read_state, store_config, store_state};
 use crate::third_msg::StakingRewardsExecuteMsg;
 use cosmwasm_std::{
-    attr, to_binary, Addr, Api, Coin, CosmosMsg, DepsMut, Env, MessageInfo, Response,
-    StdResult, Uint128, WasmMsg,
+    attr, to_binary, Addr, Api, Coin, CosmosMsg, DepsMut, Env, MessageInfo, Response, StdResult,
+    Uint128, WasmMsg,
 };
 
 pub fn optional_addr_validate(api: &dyn Api, addr: Option<String>) -> StdResult<Option<Addr>> {
@@ -19,7 +19,6 @@ pub fn optional_addr_validate(api: &dyn Api, addr: Option<String>) -> StdResult<
 pub fn update_config(
     deps: DepsMut,
     info: MessageInfo,
-    owner_addr: Option<Addr>,
     threshold: Option<Uint128>,
     rewards_contract: Option<Addr>,
     rewards_denom: Option<String>,
@@ -32,10 +31,6 @@ pub fn update_config(
             "update_config".to_string(),
             info.sender.to_string(),
         ));
-    }
-
-    if let Some(owner_addr) = owner_addr {
-        config.owner = deps.api.addr_canonicalize(owner_addr.as_str())?
     }
 
     if let Some(threshold) = threshold {
@@ -55,15 +50,15 @@ pub fn update_config(
     Ok(Response::default())
 }
 
-pub fn distribute_rewards(
-    deps: DepsMut,
-    env: Env,
-) -> Result<Response, ContractError> {
+pub fn distribute_rewards(deps: DepsMut, env: Env) -> Result<Response, ContractError> {
     let config = read_config(deps.storage)?;
     let mut state = read_state(deps.storage)?;
 
-
-    let rewards_balance = query_balance(deps.as_ref(), env.contract.address, config.rewards_denom.clone())?;
+    let rewards_balance = query_balance(
+        deps.as_ref(),
+        env.contract.address,
+        config.rewards_denom.clone(),
+    )?;
     if rewards_balance < config.threshold {
         return Err(ContractError::DistributeRewardsLessThanThreshold(
             config.threshold,
@@ -83,7 +78,7 @@ pub fn distribute_rewards(
                 .api
                 .addr_humanize(&config.rewards_contract)?
                 .to_string(),
-            msg: to_binary(&StakingRewardsExecuteMsg::NotifyRewardAmount { })?,
+            msg: to_binary(&StakingRewardsExecuteMsg::NotifyRewardAmount {})?,
             funds: vec![Coin {
                 denom: config.rewards_denom,
                 amount: rewards_balance,
@@ -94,4 +89,54 @@ pub fn distribute_rewards(
             attr("distributed_amount", rewards_balance.to_string()),
             attr("distributed_total", total.to_string()),
         ]))
+}
+
+pub fn set_owner(
+    deps: DepsMut,
+    info: MessageInfo,
+    new_owner: Addr,
+) -> Result<Response, ContractError> {
+    let mut config = read_config(deps.storage)?;
+    let sender_raw = deps.api.addr_canonicalize(info.sender.as_str())?;
+    if sender_raw != config.owner {
+        return Err(ContractError::Unauthorized(
+            "set_owner".to_string(),
+            info.sender.to_string(),
+        ));
+    }
+    deps.api.addr_validate(new_owner.clone().as_str())?;
+
+    config.new_owner = Some(deps.api.addr_canonicalize(new_owner.as_str())?);
+    store_config(deps.storage, &config)?;
+    Ok(Response::new().add_attributes(vec![
+        ("action", "set_owner"),
+        ("new_owner", new_owner.to_string().as_str()),
+    ]))
+}
+
+pub fn accept_ownership(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+) -> Result<Response, ContractError> {
+    let mut config = read_config(deps.storage)?;
+    let sender_raw = deps.api.addr_canonicalize(info.sender.as_str())?;
+    if config.new_owner.is_none() {
+        return Err(ContractError::NoNewOwner {});
+    }
+    if sender_raw != config.new_owner.unwrap() {
+        return Err(ContractError::Unauthorized(
+            "accept_ownership".to_string(),
+            info.sender.to_string(),
+        ));
+    }
+
+    config.owner = sender_raw;
+    config.new_owner = None;
+    store_config(deps.storage, &config)?;
+    Ok(Response::new().add_attributes(vec![
+        ("action", "accept_ownership"),
+        ("owner", config.owner.clone().to_string().as_str()),
+        ("new_owner", ""),
+    ]))
 }

--- a/contracts/keeper/src/msg.rs
+++ b/contracts/keeper/src/msg.rs
@@ -1,11 +1,11 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::Uint128;
+use cosmwasm_std::{Addr, Uint128};
 
 #[cw_serde]
 pub struct InstantiateMsg {
     pub owner: String,
     pub threshold: Uint128,
-    /// contract address of seilor fund 
+    /// contract address of seilor fund
     pub rewards_contract: String,
     pub rewards_denom: String,
 }
@@ -13,12 +13,15 @@ pub struct InstantiateMsg {
 #[cw_serde]
 pub enum ExecuteMsg {
     UpdateConfig {
-        owner: Option<String>,
         threshold: Option<Uint128>,
         rewards_contract: Option<String>,
         rewards_denom: Option<String>,
     },
     Distribute {},
+    SetOwner {
+        owner: Addr,
+    },
+    AcceptOwnership {},
 }
 
 #[cw_serde]
@@ -36,6 +39,7 @@ pub struct ConfigResponse {
     pub threshold: Uint128,
     pub rewards_contract: String,
     pub rewards_denom: String,
+    pub new_owner: Option<String>,
 }
 
 #[cw_serde]

--- a/contracts/keeper/src/querier.rs
+++ b/contracts/keeper/src/querier.rs
@@ -5,7 +5,10 @@ use cosmwasm_std::{Addr, BalanceResponse, BankQuery, Deps, QueryRequest, StdResu
 
 pub fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
     let config = read_config(deps.storage)?;
-
+    let mut new_owner: Option<String> = None;
+    if let Some(addr) = config.new_owner {
+        new_owner = Some(deps.api.addr_humanize(&addr)?.to_string());
+    }
     Ok(ConfigResponse {
         owner: deps.api.addr_humanize(&config.owner)?.to_string(),
         threshold: config.threshold,
@@ -14,6 +17,7 @@ pub fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
             .addr_humanize(&config.rewards_contract)?
             .to_string(),
         rewards_denom: config.rewards_denom,
+        new_owner,
     })
 }
 

--- a/contracts/keeper/src/state.rs
+++ b/contracts/keeper/src/state.rs
@@ -1,29 +1,27 @@
-use cosmwasm_std::{StdResult, Storage, Uint128, CanonicalAddr};
-use cosmwasm_storage::{Singleton, ReadonlySingleton};
+use cosmwasm_std::{CanonicalAddr, StdResult, Storage, Uint128};
+use cosmwasm_storage::{ReadonlySingleton, Singleton};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-
 
 const KEY_CONFIG: &[u8] = b"config";
 const KEY_STATE: &[u8] = b"state";
 
-
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct Config{
+pub struct Config {
     pub owner: CanonicalAddr,
     pub threshold: Uint128,
     pub rewards_contract: CanonicalAddr,
     pub rewards_denom: String,
+    pub new_owner: Option<CanonicalAddr>,
 }
 
-
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct State{
+pub struct State {
     // Duration of rewards to be paid out (in seconds) 2_592_000 = 30 days
     pub distributed_amount: Uint128,
     // Timestamp of when the keeper distribute reward to users
     pub update_time: Uint128,
-    // total rewards from staking reward on chain 
+    // total rewards from staking reward on chain
     pub distributed_total: Uint128,
 }
 
@@ -42,4 +40,3 @@ pub fn store_state(storage: &mut dyn Storage, data: &State) -> StdResult<()> {
 pub fn read_state(storage: &dyn Storage) -> StdResult<State> {
     ReadonlySingleton::new(storage, KEY_STATE).load()
 }
-

--- a/contracts/keeper/src/testing/tests.rs
+++ b/contracts/keeper/src/testing/tests.rs
@@ -32,6 +32,7 @@ mod tests {
                 threshold: Uint128::from(threshold),
                 rewards_contract: "seilor_fund".to_string(),
                 rewards_denom: "kUSD".to_string(),
+                new_owner: None,
             }
         );
     }
@@ -79,6 +80,7 @@ mod tests {
                 threshold: Uint128::from(threshold2),
                 rewards_contract: "new_fund".to_string(),
                 rewards_denom: "new_kUSD".to_string(),
+                new_owner: None,
             }
         );
 

--- a/contracts/seilor/src/contract.rs
+++ b/contracts/seilor/src/contract.rs
@@ -1,4 +1,4 @@
-use crate::handler::{mint, update_config};
+use crate::handler::{accept_gov, mint, set_gov, update_config};
 use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 use crate::querier::query_seilor_config;
 use crate::state::{store_seilor_config, SeilorConfig};
@@ -70,6 +70,7 @@ pub fn instantiate(
         fund: Addr::unchecked(""),
         gov,
         distribute: Addr::unchecked(""),
+        new_gov: None,
     };
 
     store_seilor_config(deps.storage, &seilor_config)?;
@@ -87,11 +88,9 @@ pub fn execute(
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
     match msg {
-        ExecuteMsg::UpdateConfig {
-            fund,
-            gov,
-            distribute,
-        } => update_config(deps, info, fund, gov, distribute),
+        ExecuteMsg::UpdateConfig { fund, distribute } => {
+            update_config(deps, info, fund, distribute)
+        }
         ExecuteMsg::Mint {
             recipient,
             amount,
@@ -149,6 +148,8 @@ pub fn execute(
         ExecuteMsg::UpdateMinter { new_minter } => {
             execute_update_minter(deps, env, info, new_minter)
         }
+        ExecuteMsg::SetGov { gov } => set_gov(deps, info, gov),
+        ExecuteMsg::AcceptGov {} => accept_gov(deps, info),
     }
 }
 

--- a/contracts/seilor/src/msg.rs
+++ b/contracts/seilor/src/msg.rs
@@ -16,7 +16,6 @@ pub struct InstantiateMsg {
 pub enum ExecuteMsg {
     UpdateConfig {
         fund: Option<Addr>,
-        gov: Option<Addr>,
         distribute: Option<Addr>,
     },
     Mint {
@@ -26,11 +25,19 @@ pub enum ExecuteMsg {
         msg: Option<Binary>,
     },
     /// Burn is a base message to destroy tokens forever
-    Burn { amount: Uint128 },
+    Burn {
+        amount: Uint128,
+    },
     /// Only with "approval" extension. Destroys tokens forever
-    BurnFrom { owner: String, amount: Uint128 },
+    BurnFrom {
+        owner: String,
+        amount: Uint128,
+    },
     /// Implements CW20. Transfer is a base message to move tokens to another account without triggering actions
-    Transfer { recipient: String, amount: Uint128 },
+    Transfer {
+        recipient: String,
+        amount: Uint128,
+    },
     /// Implements CW20.  Send is a base message to transfer tokens to a contract and trigger an action
     /// on the receiving contract.
     Send {
@@ -73,7 +80,9 @@ pub enum ExecuteMsg {
     /// Only with the "mintable" extension. The current minter may set
     /// a new minter. Setting the minter to None will remove the
     /// token's minter forever.
-    UpdateMinter { new_minter: Option<String> },
+    UpdateMinter {
+        new_minter: Option<String>,
+    },
     /// Only with the "marketing" extension. If authorized, updates marketing metadata.
     /// Setting None/null for any of these will leave it unchanged.
     /// Setting Some("") will clear this field on the contract storage
@@ -87,6 +96,10 @@ pub enum ExecuteMsg {
     },
     /// If set as the "marketing" role on the contract, upload a new URL, SVG, or PNG for the token
     UploadLogo(Logo),
+    SetGov {
+        gov: Addr,
+    },
+    AcceptGov {},
 }
 
 #[cw_serde]

--- a/contracts/seilor/src/state.rs
+++ b/contracts/seilor/src/state.rs
@@ -9,11 +9,15 @@ pub struct SeilorConfig {
     pub fund: Addr,
     pub gov: Addr,
     pub distribute: Addr,
+    pub new_gov: Option<Addr>,
 }
 
 const SEILOR_CONFIG: Item<SeilorConfig> = Item::new("seilor_config");
 
-pub fn store_seilor_config(storage: &mut dyn Storage, seilor_config: &SeilorConfig) -> StdResult<()> {
+pub fn store_seilor_config(
+    storage: &mut dyn Storage,
+    seilor_config: &SeilorConfig,
+) -> StdResult<()> {
     SEILOR_CONFIG.save(storage, seilor_config)
 }
 

--- a/contracts/seilor/src/testing/tests.rs
+++ b/contracts/seilor/src/testing/tests.rs
@@ -83,7 +83,6 @@ mod tests {
         let _msg = ExecuteMsg::UpdateConfig {
             fund: Some(Addr::unchecked("new_fund")),
             distribute: Some(Addr::unchecked("new_distribute")),
-            gov: Some(Addr::unchecked("new_gov")),
         };
         let _info = mock_info("random_user", &[]);
         let _res = execute(deps.as_mut(), mock_env(), _info, _msg);
@@ -107,7 +106,6 @@ mod tests {
         let _msg = ExecuteMsg::UpdateConfig {
             fund: Some(Addr::unchecked("new_fund")),
             distribute: Some(Addr::unchecked("new_distribute")),
-            gov: Some(Addr::unchecked("new_gov")),
         };
         let _info = mock_info("creator", &[]);
         let _res = execute(deps.as_mut(), mock_env(), _info, _msg).unwrap();
@@ -118,7 +116,7 @@ mod tests {
             query_seilor_config(deps.as_ref()).unwrap(),
             SeilorConfigResponse {
                 max_supply,
-                gov: Addr::unchecked("new_gov"),
+                gov: Addr::unchecked("creator"),
                 fund: Addr::unchecked("new_fund"),
                 distribute: Addr::unchecked("new_distribute"),
             }
@@ -128,9 +126,8 @@ mod tests {
         let _msg = ExecuteMsg::UpdateConfig {
             fund: Some(Addr::unchecked("new_fund")),
             distribute: Some(Addr::unchecked("new_distribute")),
-            gov: Some(Addr::unchecked("new_gov")),
         };
-        let _info = mock_info("creator", &[]);
+        let _info = mock_info("creator1", &[]);
         let _res = execute(deps.as_mut(), mock_env(), _info, _msg);
         match _res {
             Err(ContractError::Unauthorized {}) => {}
@@ -190,7 +187,6 @@ mod tests {
         let _msg = ExecuteMsg::UpdateConfig {
             fund: Some(Addr::unchecked("new_fund".to_string())),
             distribute: Some(Addr::unchecked("new_distribute".to_string())),
-            gov: Some(Addr::unchecked("new_gov".to_string())),
         };
         let _info = mock_info("creator", &[]);
         let _res = execute(deps.as_mut(), mock_env(), _info, _msg).unwrap();
@@ -265,7 +261,6 @@ mod tests {
         let _msg = ExecuteMsg::UpdateConfig {
             fund: Some(Addr::unchecked("new_fund".to_string())),
             distribute: Some(Addr::unchecked("new_distribute".to_string())),
-            gov: Some(Addr::unchecked("creator".to_string())),
         };
         let _info = mock_info("creator", &[]);
         let _res = execute(deps.as_mut(), mock_env(), _info, _msg).unwrap();

--- a/contracts/staking/src/constract.rs
+++ b/contracts/staking/src/constract.rs
@@ -1,7 +1,7 @@
 use crate::error::ContractError;
 use crate::handler::{
-    get_reward, notify_reward_amount, receive_cw20, update_staking_config, update_staking_duration,
-    withdraw,
+    accept_gov, get_reward, notify_reward_amount, receive_cw20, set_gov, update_staking_config,
+    update_staking_duration, withdraw,
 };
 use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 use crate::querier::{
@@ -38,6 +38,7 @@ pub fn instantiate(
         boost: msg.boost,
         fund: msg.fund,
         reward_controller_addr: msg.reward_controller_addr,
+        new_gov: None,
     };
 
     store_staking_config(deps.storage, &staking_config)?;
@@ -77,6 +78,8 @@ pub fn execute(
         ExecuteMsg::GetReward {} => get_reward(deps, env, info),
         ExecuteMsg::NotifyRewardAmount { amount } => notify_reward_amount(deps, env, info, amount),
         ExecuteMsg::Withdraw { amount } => withdraw(deps, env, info, amount),
+        ExecuteMsg::SetGov { gov } => set_gov(deps, info, gov),
+        ExecuteMsg::AcceptGov {} => accept_gov(deps, info),
     }
 }
 

--- a/contracts/staking/src/error.rs
+++ b/contracts/staking/src/error.rs
@@ -14,4 +14,6 @@ pub enum ContractError {
 
     #[error("Invalid input")]
     InvalidInput {},
+    #[error("No new gov")]
+    NoNewGov {},
 }

--- a/contracts/staking/src/msg.rs
+++ b/contracts/staking/src/msg.rs
@@ -4,7 +4,6 @@ use cw20::Cw20ReceiveMsg;
 
 #[cw_serde]
 pub struct UpdateStakingConfigStruct {
-    pub gov: Option<Addr>,
     pub staking_token: Option<Addr>,
     pub rewards_token: Option<Addr>,
     pub boost: Option<Addr>,
@@ -83,6 +82,10 @@ pub enum ExecuteMsg {
     NotifyRewardAmount {
         amount: Uint128,
     },
+    SetGov {
+        gov: Addr,
+    },
+    AcceptGov {},
 }
 
 #[cw_serde]

--- a/contracts/staking/src/state.rs
+++ b/contracts/staking/src/state.rs
@@ -12,6 +12,7 @@ pub struct StakingConfig {
     pub boost: Addr,
     pub fund: Addr,
     pub reward_controller_addr: Addr,
+    pub new_gov: Option<Addr>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/contracts/staking/src/testing/integration.rs
+++ b/contracts/staking/src/testing/integration.rs
@@ -8,8 +8,8 @@ use crate::msg::{
 };
 use crate::testing::mock_fn::{mock_instantiate_msg, CREATOR, REWARD_CONTROLLER_ADDR};
 use crate::testing::mock_third_fn::{
-    mock_fund_instance_msg, mock_seilor_instance_msg, mock_staking_token_instance_msg,
-    mock_boost_instance_msg, mock_ve_seilor_instance_msg,
+    mock_boost_instance_msg, mock_fund_instance_msg, mock_seilor_instance_msg,
+    mock_staking_token_instance_msg, mock_ve_seilor_instance_msg,
 };
 use cosmwasm_std::testing::mock_env;
 use cosmwasm_std::{to_binary, Addr, Coin, Timestamp, Uint128};
@@ -493,7 +493,12 @@ fn set_ve_seilor_miners(
         contracts,
         is_minter,
     };
-    let res = app.execute_contract(creator.clone(), ve_seilor.clone(), &ve_seilor_miner_msg, &[]);
+    let res = app.execute_contract(
+        creator.clone(),
+        ve_seilor.clone(),
+        &ve_seilor_miner_msg,
+        &[],
+    );
     assert!(res.is_ok());
 }
 
@@ -510,10 +515,14 @@ fn set_ve_seilor_to_fund(creator: &Addr, app: &mut App, ve_seilor: &Addr, fund: 
 fn set_seilor_to_fund(creator: &Addr, app: &mut App, seilor: &Addr, fund: &Addr) {
     let update_seilor_fund_msg = seilor::msg::ExecuteMsg::UpdateConfig {
         fund: Some(fund.clone()),
-        gov: None,
         distribute: None,
     };
-    let res = app.execute_contract(creator.clone(), seilor.clone(), &update_seilor_fund_msg, &[]);
+    let res = app.execute_contract(
+        creator.clone(),
+        seilor.clone(),
+        &update_seilor_fund_msg,
+        &[],
+    );
     assert!(res.is_ok());
 }
 

--- a/contracts/staking/src/testing/mock_third_fn.rs
+++ b/contracts/staking/src/testing/mock_third_fn.rs
@@ -1,6 +1,7 @@
 use crate::testing::mock_fn::{CREATOR, KUSD_DENOM, KUSD_REWARD_ADDR};
-use cosmwasm_std::{Addr, Uint128, Uint64};
 use boost::state::VeSeilorLockSetting;
+use cosmwasm_std::{Addr, Uint128, Uint64};
+use cw20_base::msg::InstantiateMarketingInfo;
 
 pub fn mock_staking_token_instance_msg() -> cw20_base::msg::InstantiateMsg {
     let cw20_init_msg = cw20_base::msg::InstantiateMsg {
@@ -12,7 +13,12 @@ pub fn mock_staking_token_instance_msg() -> cw20_base::msg::InstantiateMsg {
             amount: Uint128::from(100000000000u128),
         }],
         mint: None,
-        marketing: None,
+        marketing: Some(InstantiateMarketingInfo {
+            project: None,
+            description: None,
+            marketing: Some("aass".to_string()),
+            logo: None,
+        }),
     };
     cw20_init_msg
 }
@@ -25,7 +31,12 @@ pub fn mock_ve_seilor_instance_msg() -> ve_seilor::msg::InstantiateMsg {
             decimals: 6,
             initial_balances: vec![],
             mint: None,
-            marketing: None,
+            marketing: Some(InstantiateMarketingInfo {
+                project: None,
+                description: None,
+                marketing: Some("aass".to_string()),
+                logo: None,
+            }),
         },
         max_supply: 990000000000000u128,
         gov: None,
@@ -70,7 +81,12 @@ pub fn mock_seilor_instance_msg() -> seilor::msg::InstantiateMsg {
                 amount: Uint128::from(10000000000000u128),
             }],
             mint: None,
-            marketing: None,
+            marketing: Some(InstantiateMarketingInfo {
+                project: None,
+                description: None,
+                marketing: Some("aass".to_string()),
+                logo: None,
+            }),
         },
         max_supply: 1000000000000000u128,
         gov: None,

--- a/contracts/staking/src/testing/tests.rs
+++ b/contracts/staking/src/testing/tests.rs
@@ -3,8 +3,8 @@ use crate::msg::UpdateStakingConfigStruct;
 use crate::querier::query_staking_state;
 use crate::state::read_staking_config;
 use crate::testing::mock_fn::{
-    mock_instantiate, mock_instantiate_msg, FUND_ADDR, REWARD_TOKEN_ADDR, STAKING_TOKEN_ADDR,
-    BOOST_ADDR,
+    mock_instantiate, mock_instantiate_msg, BOOST_ADDR, FUND_ADDR, REWARD_TOKEN_ADDR,
+    STAKING_TOKEN_ADDR,
 };
 use cosmwasm_std::{Addr, Uint128};
 
@@ -30,7 +30,6 @@ fn test_update_staking_config() {
     let msg = mock_instantiate_msg(staking_token, rewards_token, boost, fund);
     let (mut deps, _, info, _) = mock_instantiate(msg.clone());
     let update_config_msg = UpdateStakingConfigStruct {
-        gov: Some(Addr::unchecked("new_gov".to_string())),
         staking_token: Some(Addr::unchecked("new_staking_token".to_string())),
         rewards_token: Some(Addr::unchecked("new_rewards_token".to_string())),
         boost: Some(Addr::unchecked("new_boost".to_string())),
@@ -40,7 +39,7 @@ fn test_update_staking_config() {
     let res = update_staking_config(deps.as_mut(), info.clone(), update_config_msg);
     assert!(res.is_ok());
     let staking_config = read_staking_config(&deps.storage).unwrap();
-    assert_eq!(staking_config.gov, Addr::unchecked("new_gov".to_string()));
+    assert_eq!(staking_config.gov, Addr::unchecked("creator".to_string()));
     assert_eq!(
         staking_config.staking_token,
         Addr::unchecked("new_staking_token".to_string())
@@ -53,10 +52,7 @@ fn test_update_staking_config() {
         staking_config.boost,
         Addr::unchecked("new_boost".to_string())
     );
-    assert_eq!(
-        staking_config.fund,
-        Addr::unchecked("new_fund".to_string())
-    );
+    assert_eq!(staking_config.fund, Addr::unchecked("new_fund".to_string()));
     assert_eq!(
         staking_config.reward_controller_addr,
         Addr::unchecked("new_reward_controller_addr".to_string())

--- a/contracts/treasure/src/contract.rs
+++ b/contracts/treasure/src/contract.rs
@@ -1,5 +1,7 @@
 use crate::error::ContractError;
-use crate::handler::{pre_mint_nft, receive_cw20, update_config, user_unlock, user_withdraw};
+use crate::handler::{
+    accept_gov, pre_mint_nft, receive_cw20, set_gov, update_config, user_unlock, user_withdraw,
+};
 use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 use crate::querier::{query_config_infos, query_user_infos};
 use crate::state::{store_treasure_config, store_treasure_state, TreasureConfig, TreasureState};
@@ -38,6 +40,7 @@ pub fn instantiate(
         nft_end_pre_mint_time: msg.nft_end_pre_mint_time,
         no_delay_punish_coefficient: msg.no_delay_punish_coefficient,
         mint_nft_cost_dust: msg.mint_nft_cost_dust,
+        new_gov: None,
     };
 
     let state = TreasureState {
@@ -73,6 +76,8 @@ pub fn execute(
         ExecuteMsg::UserWithdraw { amount } => user_withdraw(deps, env, info, amount),
         ExecuteMsg::UserUnlock { amount } => user_unlock(deps, env, info, amount),
         ExecuteMsg::PreMintNft { mint_num } => pre_mint_nft(deps, env, info, mint_num),
+        ExecuteMsg::SetGov { gov } => set_gov(deps, info, gov),
+        ExecuteMsg::AcceptGov {} => accept_gov(deps, info),
     }
 }
 

--- a/contracts/treasure/src/error.rs
+++ b/contracts/treasure/src/error.rs
@@ -45,4 +45,6 @@ pub enum ContractError {
     PreMintTimeEnd {},
     #[error("LockTimeNotEnd")]
     LockTimeNotEnd {},
+    #[error("No New Gov")]
+    NoNewGov {},
 }

--- a/contracts/treasure/src/msg.rs
+++ b/contracts/treasure/src/msg.rs
@@ -5,7 +5,6 @@ use std::collections::HashSet;
 
 #[cw_serde]
 pub struct TreasureConfigMsg {
-    pub gov: Option<Addr>,
     pub lock_token: Option<Addr>,
     pub start_lock_time: Option<u64>,
     pub end_lock_time: Option<u64>,
@@ -49,6 +48,8 @@ pub enum ExecuteMsg {
     UserWithdraw { amount: Uint128 },
     UserUnlock { amount: Uint128 },
     PreMintNft { mint_num: u64 },
+    SetGov { gov: Addr },
+    AcceptGov {},
 }
 
 #[cw_serde]

--- a/contracts/treasure/src/state.rs
+++ b/contracts/treasure/src/state.rs
@@ -28,6 +28,7 @@ pub struct TreasureConfig {
     pub mint_nft_cost_dust: Uint128,
     pub winning_num: HashSet<u64>,
     pub mod_num: u64,
+    pub new_gov: Option<Addr>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/contracts/treasure/src/testing/mock_third_fn.rs
+++ b/contracts/treasure/src/testing/mock_third_fn.rs
@@ -1,6 +1,7 @@
 use crate::testing::mock_fn::CREATOR;
 use cosmwasm_std::Uint128;
 use cw20::Cw20Coin;
+use cw20_base::msg::InstantiateMarketingInfo;
 
 pub fn mock_cw20_instantiate_msg() -> cw20_base::msg::InstantiateMsg {
     cw20_base::msg::InstantiateMsg {
@@ -12,6 +13,11 @@ pub fn mock_cw20_instantiate_msg() -> cw20_base::msg::InstantiateMsg {
             amount: Uint128::from(10000000000000000000u128),
         }],
         mint: None,
-        marketing: None,
+        marketing: Some(InstantiateMarketingInfo {
+            project: None,
+            description: None,
+            marketing: Some("aass".to_string()),
+            logo: None,
+        }),
     }
 }

--- a/contracts/treasure/src/testing/tests.rs
+++ b/contracts/treasure/src/testing/tests.rs
@@ -21,7 +21,6 @@ fn test_update_config() {
         deps.as_mut(),
         info.clone(),
         TreasureConfigMsg {
-            gov: Option::from(Addr::unchecked("new_gov".to_string())),
             lock_token: Option::from(Addr::unchecked("new_lock_token".to_string())),
             start_lock_time: Option::from(11111),
             end_lock_time: Option::from(11112),
@@ -42,7 +41,7 @@ fn test_update_config() {
     let new_config = crate::querier::query_config_infos(deps.as_ref()).unwrap();
     assert_eq!(
         new_config.config.gov,
-        Addr::unchecked("new_gov".to_string())
+        Addr::unchecked("creator".to_string())
     );
     assert_eq!(
         new_config.config.lock_token,

--- a/contracts/ve_seilor/src/contract.rs
+++ b/contracts/ve_seilor/src/contract.rs
@@ -1,5 +1,5 @@
 use crate::error::ContractError;
-use crate::handler::{burn, mint, set_minters, update_config};
+use crate::handler::{accept_gov, burn, mint, set_gov, set_minters, update_config};
 use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 use crate::querier::{query_is_minter, query_vote_config};
 use crate::state::{store_vote_config, VoteConfig};
@@ -72,6 +72,7 @@ pub fn instantiate(
         gov,
         max_minted: Uint128::from(msg.max_minted),
         total_minted: Uint128::from(0u128),
+        new_gov: None,
     };
 
     store_vote_config(deps.storage, &vote_config)?;
@@ -87,11 +88,9 @@ pub fn execute(
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
     match msg {
-        ExecuteMsg::UpdateConfig {
-            max_minted,
-            fund,
-            gov,
-        } => update_config(deps, info, max_minted, fund, gov),
+        ExecuteMsg::UpdateConfig { max_minted, fund } => {
+            update_config(deps, info, max_minted, fund)
+        }
         ExecuteMsg::SetMinters {
             contracts,
             is_minter,
@@ -128,6 +127,8 @@ pub fn execute(
             }
             Ok(res.unwrap())
         }
+        ExecuteMsg::SetGov { gov } => set_gov(deps, info, gov),
+        ExecuteMsg::AcceptGov {} => accept_gov(deps, info),
     }
 }
 

--- a/contracts/ve_seilor/src/error.rs
+++ b/contracts/ve_seilor/src/error.rs
@@ -20,4 +20,6 @@ pub enum ContractError {
 
     #[error("Missing marketing info")]
     MissingMarketingInfo {},
+    #[error("No new gov")]
+    NoNewGov {},
 }

--- a/contracts/ve_seilor/src/msg.rs
+++ b/contracts/ve_seilor/src/msg.rs
@@ -19,7 +19,6 @@ pub enum ExecuteMsg {
     UpdateConfig {
         max_minted: Option<Uint128>,
         fund: Option<Addr>,
-        gov: Option<Addr>,
     },
     SetMinters {
         contracts: Vec<Addr>,
@@ -48,6 +47,10 @@ pub enum ExecuteMsg {
     },
     /// If set as the "marketing" role on the contract, upload a new URL, SVG, or PNG for the token
     UploadLogo(Logo),
+    SetGov {
+        gov: Addr,
+    },
+    AcceptGov {},
 }
 
 #[cw_serde]

--- a/contracts/ve_seilor/src/state.rs
+++ b/contracts/ve_seilor/src/state.rs
@@ -23,6 +23,7 @@ pub struct VoteConfig {
     pub gov: Addr,
     pub max_minted: Uint128,
     pub total_minted: Uint128,
+    pub new_gov: Option<Addr>,
 }
 
 // const DELEGATES: Map<Addr, Addr> = Map::new("delegates");

--- a/contracts/ve_seilor/src/testing/tests.rs
+++ b/contracts/ve_seilor/src/testing/tests.rs
@@ -123,7 +123,6 @@ mod tests {
         let _msg = ExecuteMsg::UpdateConfig {
             max_minted: Some(Uint128::from(max_minted)),
             fund: Some(Addr::unchecked("new_fund")),
-            gov: Some(Addr::unchecked("new_gov")),
         };
         let _info = mock_info("random_user", &[]);
         let _res = execute(deps.as_mut(), mock_env(), _info, _msg);
@@ -148,7 +147,6 @@ mod tests {
         let _msg = ExecuteMsg::UpdateConfig {
             max_minted: Some(Uint128::from(max_minted)),
             fund: Some(Addr::unchecked("new_fund")),
-            gov: Some(Addr::unchecked("new_gov")),
         };
         let _info = mock_info("creator", &[]);
         let _res = execute(deps.as_mut(), mock_env(), _info, _msg).unwrap();
@@ -159,7 +157,7 @@ mod tests {
             query_vote_config(deps.as_ref()).unwrap(),
             VoteConfigResponse {
                 max_supply,
-                gov: Addr::unchecked("new_gov"),
+                gov: Addr::unchecked("creator"),
                 fund: Addr::unchecked("new_fund"),
                 max_minted: Uint128::from(max_minted),
                 total_minted: Uint128::zero(),
@@ -170,9 +168,8 @@ mod tests {
         let _msg = ExecuteMsg::UpdateConfig {
             max_minted: Some(Uint128::from(max_minted)),
             fund: Some(Addr::unchecked("new_fund")),
-            gov: Some(Addr::unchecked("new_gov")),
         };
-        let _info = mock_info("creator", &[]);
+        let _info = mock_info("creator1", &[]);
         let _res = execute(deps.as_mut(), mock_env(), _info, _msg);
         match _res {
             Err(ContractError::Unauthorized {}) => {}
@@ -253,7 +250,6 @@ mod tests {
         let _msg = ExecuteMsg::UpdateConfig {
             max_minted: Some(Uint128::from(max_minted)),
             fund: Some(Addr::unchecked("new_fund".to_string())),
-            gov: None,
         };
         let _info = mock_info("creator", &[]);
         let _res = execute(deps.as_mut(), mock_env(), _info, _msg).unwrap();
@@ -312,7 +308,6 @@ mod tests {
         let _msg = ExecuteMsg::UpdateConfig {
             max_minted: Some(Uint128::from(max_minted)),
             fund: Some(Addr::unchecked("new_fund".to_string())),
-            gov: None,
         };
         let _info = mock_info("creator", &[]);
         let _res = execute(deps.as_mut(), mock_env(), _info, _msg).unwrap();
@@ -392,7 +387,6 @@ mod tests {
         let _msg = ExecuteMsg::UpdateConfig {
             max_minted: Some(Uint128::from(max_minted)),
             fund: Some(Addr::unchecked("new_fund".to_string())),
-            gov: Some(Addr::unchecked("creator".to_string())),
         };
         let _info = mock_info("creator", &[]);
         let _res = execute(deps.as_mut(), mock_env(), _info, _msg).unwrap();


### PR DESCRIPTION
Fixed issues 15
An incorrect use of the execute_update_config, update_config or change_owner functions in some contracts can set owner to an invalid address and inadvertently lose control of them, which cannot be undone in any way. The affected contracts are the following:

krp-token-contracts/boost
krp-token-contracts/dispatcher
krp-token-contracts/distribute
krp-token-contracts/fund
krp-token-contracts/keeper
krp-token-contracts/seilor
krp-token-contracts/staking
krp-token-contracts/treasure
krp-token-contracts/ve_seilor
It is recommended to split ownership transfer functionality into set_owner and accept_ownership functions. The latter function allows the transfer to be completed by the recipient.