### PR TITLE
Unchecked parameters in treasure contract

### DIFF
--- a/contracts/treasure/src/error.rs
+++ b/contracts/treasure/src/error.rs
@@ -47,4 +47,14 @@ pub enum ContractError {
     LockTimeNotEnd {},
     #[error("No New Gov")]
     NoNewGov {},
+    #[error("Invalid Start Lock Time")]
+    InvalidStartLockTime {},
+    #[error("Invalid End Lock Time")]
+    InvalidEndLockTime {},
+    #[error("Invalid Nft Start Pre Mint Time")]
+    InvalidNftStartPreMintTime {},
+    #[error("Invalid Nft End Pre Mint Time And end Lock Time")]
+    InvalidNftStartPreMintTimeAndEndLockTime {},
+    #[error("Invalid Nft End Pre Mint Time")]
+    InvalidNftEndPreMintTime {},
 }

--- a/contracts/treasure/src/testing/mock_fn.rs
+++ b/contracts/treasure/src/testing/mock_fn.rs
@@ -17,14 +17,14 @@ pub fn mock_instantiate_msg(lock_token: Addr) -> InstantiateMsg {
         gov: None,
         lock_token,
         start_lock_time: 1688128677,
-        end_lock_time: 1690720710,
+        end_lock_time: 1689720710,
         dust_reward_per_second: Uint128::from(16534391u128), // 7days reward 10 dust
         withdraw_delay_duration: 86400 * 14,
         winning_num,
         mod_num: 100,
         punish_receiver: Addr::unchecked(PUNISH_RECEIVER.to_string()),
-        nft_start_pre_mint_time: 1690720710,
-        nft_end_pre_mint_time: 1690820710,
+        nft_start_pre_mint_time: 1690520710,
+        nft_end_pre_mint_time: 1699620710,
         no_delay_punish_coefficient: Uint128::from(300000u128),
         mint_nft_cost_dust: Uint128::from(1_000_000u128 * 10_000u128),
     }

--- a/contracts/treasure/src/testing/tests.rs
+++ b/contracts/treasure/src/testing/tests.rs
@@ -15,10 +15,11 @@ fn test_instantiate() {
 #[test]
 fn test_update_config() {
     let msg = mock_instantiate_msg(Addr::unchecked(LOCK_TOKEN.clone()));
-    let (mut deps, _env, info, _) = mock_instantiate(msg.clone());
+    let (mut deps, env, info, _) = mock_instantiate(msg.clone());
     let new_winning_num: HashSet<u64> = (75..100).collect();
     let res = update_config(
         deps.as_mut(),
+        env.clone(),
         info.clone(),
         TreasureConfigMsg {
             lock_token: Option::from(Addr::unchecked("new_lock_token".to_string())),


### PR DESCRIPTION
Fixed issues 17
The instantiate or update_config functions in treasure contract do not verify the following parameters:

start_lock_time >= current block time
end_lock_time > start_lock_time
nft_start_pre_mint_time >= current block time
nft_start_pre_mint_time > end_lock_time
nft_end_pre_mint_time > nft_start_pre_mint_time