### PR TITLE
Duration is not validated in staking contract

### DIFF
--- a/contracts/staking/src/constract.rs
+++ b/contracts/staking/src/constract.rs
@@ -30,7 +30,10 @@ pub fn instantiate(
     let gov = msg.gov.unwrap_or_else(|| info.sender.clone());
 
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
+    // validate that the duration is greater than 0.
+    if msg.duration <= Uint128::zero() {
+        return Err(ContractError::InvalidDuration {});
+    }
     let staking_config = StakingConfig {
         gov,
         staking_token: msg.staking_token,

--- a/contracts/staking/src/error.rs
+++ b/contracts/staking/src/error.rs
@@ -16,4 +16,6 @@ pub enum ContractError {
     InvalidInput {},
     #[error("No new gov")]
     NoNewGov {},
+    #[error("Invalid Duration")]
+    InvalidDuration {},
 }

--- a/contracts/staking/src/handler.rs
+++ b/contracts/staking/src/handler.rs
@@ -77,6 +77,10 @@ pub fn update_staking_duration(
     if info.sender.ne(&staking_config.gov) {
         return Err(ContractError::Unauthorized {});
     }
+    // validate that the duration is greater than 0.
+    if duration <= Uint128::zero() {
+        return Err(ContractError::InvalidDuration {});
+    }
 
     let current_time = Uint128::from(env.block.time.seconds());
     if staking_state.finish_at > current_time {

--- a/contracts/staking/src/testing/integration.rs
+++ b/contracts/staking/src/testing/integration.rs
@@ -506,7 +506,6 @@ fn set_ve_seilor_to_fund(creator: &Addr, app: &mut App, ve_seilor: &Addr, fund: 
     let ve_seilor_config = ve_seilor::msg::ExecuteMsg::UpdateConfig {
         max_minted: None,
         fund: Some(fund.clone()),
-        gov: None,
     };
     let res = app.execute_contract(creator.clone(), ve_seilor.clone(), &ve_seilor_config, &[]);
     assert!(res.is_ok());


### PR DESCRIPTION
Fixed issues 18
The instantiate and update_staking_duration functions in staking contract do not validate that the duration is greater than 0.