### PR TITLE
Unreliable source of randomness (Delete this business block)

### DIFF
--- a/contracts/treasure/src/contract.rs
+++ b/contracts/treasure/src/contract.rs
@@ -1,6 +1,6 @@
 use crate::error::ContractError;
 use crate::handler::{
-    accept_gov, pre_mint_nft, receive_cw20, set_gov, update_config, user_unlock, user_withdraw,
+    accept_gov, receive_cw20, set_gov, update_config, user_unlock, user_withdraw,
 };
 use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 use crate::querier::{query_config_infos, query_user_infos};
@@ -39,30 +39,30 @@ pub fn instantiate(
     if msg.end_lock_time <= msg.start_lock_time {
         return Err(ContractError::InvalidEndLockTime {});
     }
-    if msg.nft_start_pre_mint_time < current_block_time {
-        return Err(ContractError::InvalidNftStartPreMintTime {});
-    }
-    if msg.nft_start_pre_mint_time <= msg.end_lock_time {
-        return Err(ContractError::InvalidNftStartPreMintTimeAndEndLockTime {});
-    }
-    if msg.nft_end_pre_mint_time <= msg.nft_start_pre_mint_time {
-        return Err(ContractError::InvalidNftEndPreMintTime {});
-    }
+    // if msg.nft_start_pre_mint_time < current_block_time {
+    //     return Err(ContractError::InvalidNftStartPreMintTime {});
+    // }
+    // if msg.nft_start_pre_mint_time <= msg.end_lock_time {
+    //     return Err(ContractError::InvalidNftStartPreMintTimeAndEndLockTime {});
+    // }
+    // if msg.nft_end_pre_mint_time <= msg.nft_start_pre_mint_time {
+    //     return Err(ContractError::InvalidNftEndPreMintTime {});
+    // }
 
     let config = TreasureConfig {
         gov: gov.clone(),
         lock_token: msg.lock_token.clone(),
         start_lock_time: msg.start_lock_time,
         end_lock_time: msg.end_lock_time,
-        dust_reward_per_second: msg.dust_reward_per_second,
+        // dust_reward_per_second: msg.dust_reward_per_second,
         withdraw_delay_duration: msg.withdraw_delay_duration,
-        winning_num: msg.winning_num,
-        mod_num: msg.mod_num,
+        // winning_num: msg.winning_num,
+        // mod_num: msg.mod_num,
         punish_receiver: msg.punish_receiver,
-        nft_start_pre_mint_time: msg.nft_start_pre_mint_time,
-        nft_end_pre_mint_time: msg.nft_end_pre_mint_time,
+        // nft_start_pre_mint_time: msg.nft_start_pre_mint_time,
+        // nft_end_pre_mint_time: msg.nft_end_pre_mint_time,
         no_delay_punish_coefficient: msg.no_delay_punish_coefficient,
-        mint_nft_cost_dust: msg.mint_nft_cost_dust,
+        // mint_nft_cost_dust: msg.mint_nft_cost_dust,
         new_gov: None,
     };
 
@@ -73,9 +73,9 @@ pub fn instantiate(
         total_unlock_amount: Uint128::zero(),
         total_withdraw_amount: Uint128::zero(),
         total_punish_amount: Uint128::zero(),
-        total_cost_dust_amount: Uint128::zero(),
-        total_win_nft_num: 0,
-        total_lose_nft_num: 0,
+        // total_cost_dust_amount: Uint128::zero(),
+        // total_win_nft_num: 0,
+        // total_lose_nft_num: 0,
     };
 
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
@@ -98,7 +98,7 @@ pub fn execute(
         ExecuteMsg::UpdateConfig(msg) => update_config(deps, env, info, msg),
         ExecuteMsg::UserWithdraw { amount } => user_withdraw(deps, env, info, amount),
         ExecuteMsg::UserUnlock { amount } => user_unlock(deps, env, info, amount),
-        ExecuteMsg::PreMintNft { mint_num } => pre_mint_nft(deps, env, info, mint_num),
+        // ExecuteMsg::PreMintNft { mint_num } => pre_mint_nft(deps, env, info, mint_num),
         ExecuteMsg::SetGov { gov } => set_gov(deps, info, gov),
         ExecuteMsg::AcceptGov {} => accept_gov(deps, info),
     }

--- a/contracts/treasure/src/handler.rs
+++ b/contracts/treasure/src/handler.rs
@@ -1,11 +1,11 @@
 use crate::error::ContractError;
 use crate::helper::BASE_RATE_6;
 use crate::msg::{Cw20HookMsg, TreasureConfigMsg};
-use crate::querier::compute_user_dust;
-use crate::random_rules::get_winning;
+// use crate::querier::compute_user_dust;
+// use crate::random_rules::get_winning;
 use crate::state::{
-    generate_next_global_id, read_treasure_config, read_treasure_state, read_treasure_user_state,
-    store_treasure_config, store_treasure_user_state,
+    read_treasure_config, read_treasure_state, read_treasure_user_state, store_treasure_config,
+    store_treasure_user_state,
 };
 use cosmwasm_std::{
     attr, from_binary, to_binary, Addr, CosmosMsg, DepsMut, Env, MessageInfo, Response, Uint128,
@@ -46,13 +46,13 @@ pub fn update_config(
         config.end_lock_time = end_lock_time.clone();
         attrs.push(attr("end_lock_time", end_lock_time.to_string()));
     }
-    if let Some(dust_reward_per_second) = config_msg.dust_reward_per_second {
-        config.dust_reward_per_second = dust_reward_per_second.clone();
-        attrs.push(attr(
-            "dust_reward_per_second",
-            dust_reward_per_second.to_string(),
-        ));
-    }
+    // if let Some(dust_reward_per_second) = config_msg.dust_reward_per_second {
+    //     config.dust_reward_per_second = dust_reward_per_second.clone();
+    //     attrs.push(attr(
+    //         "dust_reward_per_second",
+    //         dust_reward_per_second.to_string(),
+    //     ));
+    // }
     if let Some(withdraw_delay_duration) = config_msg.withdraw_delay_duration {
         config.withdraw_delay_duration = withdraw_delay_duration.clone();
         attrs.push(attr(
@@ -73,50 +73,50 @@ pub fn update_config(
         attrs.push(attr("punish_receiver", punish_receiver.to_string()));
     }
 
-    if let Some(nft_start_pre_mint_time) = config_msg.nft_start_pre_mint_time {
-        // nft_start_pre_mint_time >= current block time
-        if nft_start_pre_mint_time < current_block_time {
-            return Err(ContractError::InvalidNftStartPreMintTime {});
-        }
-        // nft_start_pre_mint_time > end_lock_time
-        if nft_start_pre_mint_time <= config.end_lock_time {
-            return Err(ContractError::InvalidNftStartPreMintTimeAndEndLockTime {});
-        }
-
-        config.nft_start_pre_mint_time = nft_start_pre_mint_time.clone();
-        attrs.push(attr(
-            "nft_start_pre_mint_time",
-            nft_start_pre_mint_time.to_string(),
-        ));
-    }
-    if let Some(nft_end_pre_mint_time) = config_msg.nft_end_pre_mint_time {
-        // nft_end_pre_mint_time > nft_start_pre_mint_time
-        if nft_end_pre_mint_time <= config.nft_start_pre_mint_time {
-            return Err(ContractError::InvalidNftEndPreMintTime {});
-        }
-        config.nft_end_pre_mint_time = nft_end_pre_mint_time.clone();
-        attrs.push(attr(
-            "nft_end_pre_mint_time",
-            nft_end_pre_mint_time.to_string(),
-        ));
-    }
-    if let Some(mint_nft_cost_dust) = config_msg.mint_nft_cost_dust {
-        config.mint_nft_cost_dust = mint_nft_cost_dust.clone();
-        attrs.push(attr("mint_nft_cost_dust", mint_nft_cost_dust.to_string()));
-    }
-    if let Some(winning_num) = config_msg.winning_num {
-        config.winning_num = winning_num.clone();
-        let set_string = winning_num
-            .iter()
-            .map(|x| x.to_string())
-            .collect::<Vec<String>>()
-            .join(", ");
-        attrs.push(attr("winning_num", set_string));
-    }
-    if let Some(mod_num) = config_msg.mod_num {
-        config.mod_num = mod_num.clone();
-        attrs.push(attr("mod_num", mod_num.to_string()));
-    }
+    // if let Some(nft_start_pre_mint_time) = config_msg.nft_start_pre_mint_time {
+    //     // nft_start_pre_mint_time >= current block time
+    //     if nft_start_pre_mint_time < current_block_time {
+    //         return Err(ContractError::InvalidNftStartPreMintTime {});
+    //     }
+    //     // nft_start_pre_mint_time > end_lock_time
+    //     if nft_start_pre_mint_time <= config.end_lock_time {
+    //         return Err(ContractError::InvalidNftStartPreMintTimeAndEndLockTime {});
+    //     }
+    //
+    //     config.nft_start_pre_mint_time = nft_start_pre_mint_time.clone();
+    //     attrs.push(attr(
+    //         "nft_start_pre_mint_time",
+    //         nft_start_pre_mint_time.to_string(),
+    //     ));
+    // }
+    // if let Some(nft_end_pre_mint_time) = config_msg.nft_end_pre_mint_time {
+    //     // nft_end_pre_mint_time > nft_start_pre_mint_time
+    //     if nft_end_pre_mint_time <= config.nft_start_pre_mint_time {
+    //         return Err(ContractError::InvalidNftEndPreMintTime {});
+    //     }
+    //     config.nft_end_pre_mint_time = nft_end_pre_mint_time.clone();
+    //     attrs.push(attr(
+    //         "nft_end_pre_mint_time",
+    //         nft_end_pre_mint_time.to_string(),
+    //     ));
+    // }
+    // if let Some(mint_nft_cost_dust) = config_msg.mint_nft_cost_dust {
+    //     config.mint_nft_cost_dust = mint_nft_cost_dust.clone();
+    //     attrs.push(attr("mint_nft_cost_dust", mint_nft_cost_dust.to_string()));
+    // }
+    // if let Some(winning_num) = config_msg.winning_num {
+    //     config.winning_num = winning_num.clone();
+    //     let set_string = winning_num
+    //         .iter()
+    //         .map(|x| x.to_string())
+    //         .collect::<Vec<String>>()
+    //         .join(", ");
+    //     attrs.push(attr("winning_num", set_string));
+    // }
+    // if let Some(mod_num) = config_msg.mod_num {
+    //     config.mod_num = mod_num.clone();
+    //     attrs.push(attr("mod_num", mod_num.to_string()));
+    // }
 
     store_treasure_config(deps.storage, &config)?;
 
@@ -142,17 +142,17 @@ pub fn user_lock_hook(
     let mut user_state = read_treasure_user_state(deps.storage, &user_addr)?;
 
     //compute reward dust
-    let reward_dust_amount = compute_user_dust(
-        current_time.clone(),
-        user_state.last_lock_time.clone(),
-        config.end_lock_time.clone(),
-        user_state.current_locked_amount.clone(),
-        config.dust_reward_per_second.clone(),
-    )?;
+    // let reward_dust_amount = compute_user_dust(
+    //     current_time.clone(),
+    //     user_state.last_lock_time.clone(),
+    //     config.end_lock_time.clone(),
+    //     user_state.current_locked_amount.clone(),
+    //     config.dust_reward_per_second.clone(),
+    // )?;
 
     user_state.last_lock_time = current_time;
     user_state.current_locked_amount += lock_amount;
-    user_state.current_dust_amount += reward_dust_amount;
+    // user_state.current_dust_amount += reward_dust_amount;
     user_state.total_locked_amount += lock_amount;
 
     // global data
@@ -170,7 +170,7 @@ pub fn user_lock_hook(
     attrs.push(attr("action", "user_lock_hock"));
     attrs.push(attr("user_addr", user_addr.to_string()));
     attrs.push(attr("lock_amount", lock_amount.to_string()));
-    attrs.push(attr("reward_dust_amount", reward_dust_amount.to_string()));
+    // attrs.push(attr("reward_dust_amount", reward_dust_amount.to_string()));
     Ok(Response::default().add_attributes(attrs))
 }
 
@@ -212,7 +212,7 @@ pub fn user_unlock(
     info: MessageInfo,
     amount: Uint128,
 ) -> Result<Response, ContractError> {
-    let config = read_treasure_config(deps.storage)?;
+    // let config = read_treasure_config(deps.storage)?;
     let current_time = env.block.time.seconds();
     let mut user_state = read_treasure_user_state(deps.storage, &info.sender)?;
 
@@ -222,20 +222,20 @@ pub fn user_unlock(
     }
 
     //compute reward dust
-    let reward_dust_amount = compute_user_dust(
-        current_time.clone(),
-        user_state.last_lock_time.clone(),
-        config.end_lock_time.clone(),
-        user_state.current_locked_amount.clone(),
-        config.dust_reward_per_second.clone(),
-    )?;
+    // let reward_dust_amount = compute_user_dust(
+    //     current_time.clone(),
+    //     user_state.last_lock_time.clone(),
+    //     config.end_lock_time.clone(),
+    //     user_state.current_locked_amount.clone(),
+    //     config.dust_reward_per_second.clone(),
+    // )?;
 
     // update user state
     user_state.last_lock_time = current_time;
     user_state.last_unlock_time = current_time;
     user_state.current_locked_amount -= amount;
     user_state.current_unlock_amount += amount;
-    user_state.current_dust_amount += reward_dust_amount;
+    // user_state.current_dust_amount += reward_dust_amount;
     user_state.total_unlock_amount += amount;
 
     // global data
@@ -253,7 +253,7 @@ pub fn user_unlock(
         attr("action", "user_unlock"),
         attr("user_addr", info.sender.to_string()),
         attr("unlock_amount", amount.to_string()),
-        attr("reward_dust_amount", reward_dust_amount.to_string()),
+        // attr("reward_dust_amount", reward_dust_amount.to_string()),
     ];
     Ok(Response::default().add_attributes(attrs))
 }
@@ -329,98 +329,98 @@ pub fn user_withdraw(
         .add_messages(transfer_msgs))
 }
 
-pub fn pre_mint_nft(
-    deps: DepsMut,
-    env: Env,
-    info: MessageInfo,
-    mint_num: u64,
-) -> Result<Response, ContractError> {
-    if mint_num < 1u64 {
-        return Err(ContractError::InvalidMintNum {});
-    }
-
-    let config = read_treasure_config(deps.storage)?;
-    let current_time = env.block.time.seconds();
-
-    // check mint time
-    if current_time < config.nft_start_pre_mint_time {
-        return Err(ContractError::PreMintTimeNotReach {});
-    }
-    if current_time > config.nft_end_pre_mint_time {
-        return Err(ContractError::PreMintTimeEnd {});
-    }
-    if current_time < config.end_lock_time {
-        return Err(ContractError::LockTimeNotEnd {});
-    }
-
-    let mut user_state = read_treasure_user_state(deps.storage, &info.sender)?;
-
-    //compute reward dust
-    let reward_dust_amount = compute_user_dust(
-        current_time.clone(),
-        user_state.last_lock_time.clone(),
-        config.end_lock_time.clone(),
-        user_state.current_locked_amount.clone(),
-        config.dust_reward_per_second.clone(),
-    )?;
-    user_state.current_dust_amount += reward_dust_amount;
-
-    // check user dust amount
-    let mint_dust_amount = config.mint_nft_cost_dust * Uint128::from(mint_num);
-
-    if mint_dust_amount > user_state.current_dust_amount {
-        return Err(ContractError::InsufficientIntegralFunds {});
-    }
-
-    let mut win_nft_num = 0u64;
-    let mut lost_nft_num = 0u64;
-    let record_id = generate_next_global_id(deps.storage)?;
-    let winning_num = &config.winning_num;
-    let mod_num = &config.mod_num;
-    for i in 0..mint_num {
-        let unique_factor = record_id + i;
-        let winning = get_winning(
-            env.clone(),
-            unique_factor.to_string(),
-            vec![],
-            winning_num,
-            mod_num,
-        )?;
-        if winning {
-            win_nft_num += 1;
-        } else {
-            lost_nft_num += 1;
-        }
-    }
-
-    let mut global_state = read_treasure_state(deps.storage)?;
-
-    // user data
-    user_state.current_dust_amount -= mint_dust_amount;
-    user_state.total_cost_dust_amount += mint_dust_amount;
-    user_state.last_lock_time = current_time;
-
-    user_state.win_nft_num += win_nft_num;
-    user_state.lose_nft_num += lost_nft_num;
-
-    // global data
-    global_state.total_cost_dust_amount += mint_dust_amount;
-    global_state.total_win_nft_num += win_nft_num;
-    global_state.total_lose_nft_num += lost_nft_num;
-
-    // save user data
-    store_treasure_user_state(deps.storage, &info.sender, &user_state)?;
-    // save global data
-    crate::state::store_treasure_state(deps.storage, &global_state)?;
-
-    let mut attrs = vec![];
-    attrs.push(attr("action", "pre_mint_nft"));
-    attrs.push(attr("user_addr", info.sender));
-    attrs.push(attr("mint_dust_amount", mint_dust_amount.to_string()));
-    attrs.push(attr("win_nft_num", win_nft_num.to_string()));
-
-    Ok(Response::default().add_attributes(attrs))
-}
+// pub fn pre_mint_nft(
+//     deps: DepsMut,
+//     env: Env,
+//     info: MessageInfo,
+//     mint_num: u64,
+// ) -> Result<Response, ContractError> {
+//     if mint_num < 1u64 {
+//         return Err(ContractError::InvalidMintNum {});
+//     }
+//
+//     let config = read_treasure_config(deps.storage)?;
+//     let current_time = env.block.time.seconds();
+//
+//     // check mint time
+//     if current_time < config.nft_start_pre_mint_time {
+//         return Err(ContractError::PreMintTimeNotReach {});
+//     }
+//     if current_time > config.nft_end_pre_mint_time {
+//         return Err(ContractError::PreMintTimeEnd {});
+//     }
+//     if current_time < config.end_lock_time {
+//         return Err(ContractError::LockTimeNotEnd {});
+//     }
+//
+//     let mut user_state = read_treasure_user_state(deps.storage, &info.sender)?;
+//
+//     //compute reward dust
+//     let reward_dust_amount = compute_user_dust(
+//         current_time.clone(),
+//         user_state.last_lock_time.clone(),
+//         config.end_lock_time.clone(),
+//         user_state.current_locked_amount.clone(),
+//         config.dust_reward_per_second.clone(),
+//     )?;
+//     user_state.current_dust_amount += reward_dust_amount;
+//
+//     // check user dust amount
+//     let mint_dust_amount = config.mint_nft_cost_dust * Uint128::from(mint_num);
+//
+//     if mint_dust_amount > user_state.current_dust_amount {
+//         return Err(ContractError::InsufficientIntegralFunds {});
+//     }
+//
+//     let mut win_nft_num = 0u64;
+//     let mut lost_nft_num = 0u64;
+//     let record_id = generate_next_global_id(deps.storage)?;
+//     let winning_num = &config.winning_num;
+//     let mod_num = &config.mod_num;
+//     for i in 0..mint_num {
+//         let unique_factor = record_id + i;
+//         let winning = get_winning(
+//             env.clone(),
+//             unique_factor.to_string(),
+//             vec![],
+//             winning_num,
+//             mod_num,
+//         )?;
+//         if winning {
+//             win_nft_num += 1;
+//         } else {
+//             lost_nft_num += 1;
+//         }
+//     }
+//
+//     let mut global_state = read_treasure_state(deps.storage)?;
+//
+//     // user data
+//     user_state.current_dust_amount -= mint_dust_amount;
+//     user_state.total_cost_dust_amount += mint_dust_amount;
+//     user_state.last_lock_time = current_time;
+//
+//     user_state.win_nft_num += win_nft_num;
+//     user_state.lose_nft_num += lost_nft_num;
+//
+//     // global data
+//     global_state.total_cost_dust_amount += mint_dust_amount;
+//     global_state.total_win_nft_num += win_nft_num;
+//     global_state.total_lose_nft_num += lost_nft_num;
+//
+//     // save user data
+//     store_treasure_user_state(deps.storage, &info.sender, &user_state)?;
+//     // save global data
+//     crate::state::store_treasure_state(deps.storage, &global_state)?;
+//
+//     let mut attrs = vec![];
+//     attrs.push(attr("action", "pre_mint_nft"));
+//     attrs.push(attr("user_addr", info.sender));
+//     attrs.push(attr("mint_dust_amount", mint_dust_amount.to_string()));
+//     attrs.push(attr("win_nft_num", win_nft_num.to_string()));
+//
+//     Ok(Response::default().add_attributes(attrs))
+// }
 
 pub fn set_gov(deps: DepsMut, info: MessageInfo, gov: Addr) -> Result<Response, ContractError> {
     let mut config = read_treasure_config(deps.storage)?;

--- a/contracts/treasure/src/helper.rs
+++ b/contracts/treasure/src/helper.rs
@@ -1,2 +1,2 @@
 pub const BASE_RATE_6: u128 = 1000000u128;
-pub const BASE_RATE_12: u128 = 1_000_000_000_000u128;
+// pub const BASE_RATE_12: u128 = 1_000_000_000_000u128;

--- a/contracts/treasure/src/msg.rs
+++ b/contracts/treasure/src/msg.rs
@@ -1,22 +1,21 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Uint128};
 use cw20::Cw20ReceiveMsg;
-use std::collections::HashSet;
 
 #[cw_serde]
 pub struct TreasureConfigMsg {
     pub lock_token: Option<Addr>,
     pub start_lock_time: Option<u64>,
     pub end_lock_time: Option<u64>,
-    pub dust_reward_per_second: Option<Uint128>,
+    // pub dust_reward_per_second: Option<Uint128>,
     pub withdraw_delay_duration: Option<u64>,
     pub no_delay_punish_coefficient: Option<Uint128>,
     pub punish_receiver: Option<Addr>,
-    pub nft_start_pre_mint_time: Option<u64>,
-    pub nft_end_pre_mint_time: Option<u64>,
-    pub mint_nft_cost_dust: Option<Uint128>,
-    pub winning_num: Option<HashSet<u64>>,
-    pub mod_num: Option<u64>,
+    // pub nft_start_pre_mint_time: Option<u64>,
+    // pub nft_end_pre_mint_time: Option<u64>,
+    // pub mint_nft_cost_dust: Option<Uint128>,
+    // pub winning_num: Option<HashSet<u64>>,
+    // pub mod_num: Option<u64>,
 }
 
 #[cw_serde]
@@ -25,20 +24,20 @@ pub struct InstantiateMsg {
     pub lock_token: Addr,
     pub start_lock_time: u64,
     pub end_lock_time: u64,
-    pub dust_reward_per_second: Uint128,
+    // pub dust_reward_per_second: Uint128,
     pub withdraw_delay_duration: u64,
     // no delay punish coefficient
     pub no_delay_punish_coefficient: Uint128,
     // punish receiver
     pub punish_receiver: Addr,
     // nft start pre mint time
-    pub nft_start_pre_mint_time: u64,
+    // pub nft_start_pre_mint_time: u64,
     // nft end pre mint time
-    pub nft_end_pre_mint_time: u64,
+    // pub nft_end_pre_mint_time: u64,
     // nft cost dust
-    pub mint_nft_cost_dust: Uint128,
-    pub winning_num: HashSet<u64>,
-    pub mod_num: u64,
+    // pub mint_nft_cost_dust: Uint128,
+    // pub winning_num: HashSet<u64>,
+    // pub mod_num: u64,
 }
 
 #[cw_serde]
@@ -47,7 +46,7 @@ pub enum ExecuteMsg {
     UpdateConfig(TreasureConfigMsg),
     UserWithdraw { amount: Uint128 },
     UserUnlock { amount: Uint128 },
-    PreMintNft { mint_num: u64 },
+    // PreMintNft { mint_num: u64 },
     SetGov { gov: Addr },
     AcceptGov {},
 }

--- a/contracts/treasure/src/querier.rs
+++ b/contracts/treasure/src/querier.rs
@@ -1,7 +1,6 @@
-use crate::helper::BASE_RATE_12;
 use crate::msg::{ConfigInfosResponse, UserInfosResponse};
 use crate::state::read_treasure_config;
-use cosmwasm_std::{Addr, Deps, Env, StdResult, Uint128};
+use cosmwasm_std::{Addr, Deps, Env, StdResult};
 
 pub fn query_config_infos(deps: Deps) -> StdResult<ConfigInfosResponse> {
     let config = read_treasure_config(deps.storage)?;
@@ -9,43 +8,43 @@ pub fn query_config_infos(deps: Deps) -> StdResult<ConfigInfosResponse> {
     Ok(ConfigInfosResponse { config, state })
 }
 
-pub fn query_user_infos(deps: Deps, env: Env, user: Addr) -> StdResult<UserInfosResponse> {
-    let mut user_state = crate::state::read_treasure_user_state(deps.storage, &user)?;
-    let config = read_treasure_config(deps.storage)?;
-    let current_dust_amount = compute_user_dust(
-        env.block.time.seconds(),
-        user_state.last_lock_time,
-        config.end_lock_time,
-        user_state.current_locked_amount,
-        config.dust_reward_per_second,
-    )?;
-    user_state.current_dust_amount += current_dust_amount;
+pub fn query_user_infos(deps: Deps, _env: Env, user: Addr) -> StdResult<UserInfosResponse> {
+    let user_state = crate::state::read_treasure_user_state(deps.storage, &user)?;
+    // let config = read_treasure_config(deps.storage)?;
+    // let current_dust_amount = compute_user_dust(
+    //     env.block.time.seconds(),
+    //     user_state.last_lock_time,
+    //     config.end_lock_time,
+    //     user_state.current_locked_amount,
+    //     config.dust_reward_per_second,
+    // )?;
+    // user_state.current_dust_amount += current_dust_amount;
     Ok(UserInfosResponse { user_state })
 }
 
 // 计算用户积分奖励
-pub fn compute_user_dust(
-    block_time: u64,
-    user_last_lock_time: u64,
-    global_end_time: u64,
-    user_current_locked_amount: Uint128,
-    dust_reward_per_second: Uint128,
-) -> StdResult<Uint128> {
-    let mut dust_amount = Uint128::zero();
-
-    if user_last_lock_time < block_time
-        && user_last_lock_time < global_end_time
-        && user_current_locked_amount > Uint128::zero()
-    {
-        let diff_time;
-        if block_time > global_end_time {
-            diff_time = global_end_time - user_last_lock_time;
-        } else {
-            diff_time = block_time - user_last_lock_time;
-        }
-        dust_amount =
-            user_current_locked_amount * Uint128::from(diff_time) * dust_reward_per_second
-                / Uint128::from(BASE_RATE_12);
-    }
-    Ok(dust_amount)
-}
+// pub fn compute_user_dust(
+//     block_time: u64,
+//     user_last_lock_time: u64,
+//     global_end_time: u64,
+//     user_current_locked_amount: Uint128,
+//     dust_reward_per_second: Uint128,
+// ) -> StdResult<Uint128> {
+//     let mut dust_amount = Uint128::zero();
+//
+//     if user_last_lock_time < block_time
+//         && user_last_lock_time < global_end_time
+//         && user_current_locked_amount > Uint128::zero()
+//     {
+//         let diff_time;
+//         if block_time > global_end_time {
+//             diff_time = global_end_time - user_last_lock_time;
+//         } else {
+//             diff_time = block_time - user_last_lock_time;
+//         }
+//         dust_amount =
+//             user_current_locked_amount * Uint128::from(diff_time) * dust_reward_per_second
+//                 / Uint128::from(BASE_RATE_12);
+//     }
+//     Ok(dust_amount)
+// }

--- a/contracts/treasure/src/random_rules.rs
+++ b/contracts/treasure/src/random_rules.rs
@@ -1,82 +1,82 @@
-use cosmwasm_std::{Env, TransactionInfo};
-use sha2::{Digest, Sha256};
-use std::collections::HashSet;
-use std::num::ParseIntError;
-
-const CHARACTERS: [char; 62] = [
-    '2', 'f', 'x', 'n', 'l', 'G', 'j', 'O', 'T', 'h', 'u', 'k', 'r', 'Q', 'D', 'w', 'b', 'I', 'a',
-    'Y', '4', 'Z', 'H', 'c', 'W', 'N', 'X', 'v', 'C', 'm', '7', 's', 'F', '1', '9', 'q', '5', 'J',
-    'e', 'P', '0', '6', 'y', 'K', 'L', 'E', '8', 'p', 'i', 'M', 'R', 'A', 'B', '3', 'z', 't', 'U',
-    'g', 'V', 'S', 'o', 'd',
-];
-
-fn _get_random_seed(env: Env, unique_factor: String, rand_factor: Vec<String>) -> String {
-    let mut seed = rand_factor;
-    let block_time = env.block.time.seconds();
-    let mod_time = block_time % 62;
-    seed.push(CHARACTERS[mod_time as usize].to_string());
-    seed.push(unique_factor);
-    seed.push(env.block.time.nanos().to_string());
-    seed.push(env.block.height.to_string());
-    seed.push(
-        env.transaction
-            .unwrap_or(TransactionInfo { index: 0 })
-            .index
-            .to_string(),
-    );
-    seed.join(",").to_string()
-}
-
-fn _cal_random_number(seed: &str) -> Result<u64, ParseIntError> {
-    let result = _compute_hash(seed);
-    let random_number_bytes_first = &result[..6]; // Take the first 5 bytes
-    let random_number_bytes_last = &result[result.len() - 6..]; // Take the last 5 bytes
-    let random_number_first = u64::from_str_radix(random_number_bytes_first, 16)?; // Convert to u64 (base 16
-    let random_number_last = u64::from_str_radix(random_number_bytes_last, 16)?; // Convert to u64 (base 16
-    let random_number = random_number_first + random_number_last; // Add the two numbers
-    Ok(random_number)
-}
-
-fn _compute_hash(input: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(input);
-    let result = hasher.finalize();
-    hex::encode(result)
-}
-
-pub fn get_winning(
-    env: Env,
-    unique_factor: String,
-    rand_factor: Vec<String>,
-    winning_num: &HashSet<u64>,
-    mod_num: &u64,
-) -> Result<bool, ParseIntError> {
-    let seed = _get_random_seed(env, unique_factor.clone(), rand_factor);
-    let random_number = _cal_random_number(&seed)?;
-    let luck_num = random_number % mod_num;
-    Ok(winning_num.contains(&luck_num))
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::random_rules::get_winning;
-    use cosmwasm_std::testing::mock_env;
-
-    #[test]
-    fn test_cal_random_number() {
-        let env = mock_env();
-        let res = get_winning(
-            env,
-            "test2".to_string(),
-            vec!["1".to_string()],
-            &vec![
-                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
-                23, 24,
-            ]
-            .into_iter()
-            .collect(),
-            &100,
-        );
-        println!("res:{:?}", res);
-    }
-}
+// use cosmwasm_std::{Env, TransactionInfo};
+// use sha2::{Digest, Sha256};
+// use std::collections::HashSet;
+// use std::num::ParseIntError;
+//
+// const CHARACTERS: [char; 62] = [
+//     '2', 'f', 'x', 'n', 'l', 'G', 'j', 'O', 'T', 'h', 'u', 'k', 'r', 'Q', 'D', 'w', 'b', 'I', 'a',
+//     'Y', '4', 'Z', 'H', 'c', 'W', 'N', 'X', 'v', 'C', 'm', '7', 's', 'F', '1', '9', 'q', '5', 'J',
+//     'e', 'P', '0', '6', 'y', 'K', 'L', 'E', '8', 'p', 'i', 'M', 'R', 'A', 'B', '3', 'z', 't', 'U',
+//     'g', 'V', 'S', 'o', 'd',
+// ];
+//
+// fn _get_random_seed(env: Env, unique_factor: String, rand_factor: Vec<String>) -> String {
+//     let mut seed = rand_factor;
+//     let block_time = env.block.time.seconds();
+//     let mod_time = block_time % 62;
+//     seed.push(CHARACTERS[mod_time as usize].to_string());
+//     seed.push(unique_factor);
+//     seed.push(env.block.time.nanos().to_string());
+//     seed.push(env.block.height.to_string());
+//     seed.push(
+//         env.transaction
+//             .unwrap_or(TransactionInfo { index: 0 })
+//             .index
+//             .to_string(),
+//     );
+//     seed.join(",").to_string()
+// }
+//
+// fn _cal_random_number(seed: &str) -> Result<u64, ParseIntError> {
+//     let result = _compute_hash(seed);
+//     let random_number_bytes_first = &result[..6]; // Take the first 5 bytes
+//     let random_number_bytes_last = &result[result.len() - 6..]; // Take the last 5 bytes
+//     let random_number_first = u64::from_str_radix(random_number_bytes_first, 16)?; // Convert to u64 (base 16
+//     let random_number_last = u64::from_str_radix(random_number_bytes_last, 16)?; // Convert to u64 (base 16
+//     let random_number = random_number_first + random_number_last; // Add the two numbers
+//     Ok(random_number)
+// }
+//
+// fn _compute_hash(input: &str) -> String {
+//     let mut hasher = Sha256::new();
+//     hasher.update(input);
+//     let result = hasher.finalize();
+//     hex::encode(result)
+// }
+//
+// pub fn get_winning(
+//     env: Env,
+//     unique_factor: String,
+//     rand_factor: Vec<String>,
+//     winning_num: &HashSet<u64>,
+//     mod_num: &u64,
+// ) -> Result<bool, ParseIntError> {
+//     let seed = _get_random_seed(env, unique_factor.clone(), rand_factor);
+//     let random_number = _cal_random_number(&seed)?;
+//     let luck_num = random_number % mod_num;
+//     Ok(winning_num.contains(&luck_num))
+// }
+//
+// #[cfg(test)]
+// mod tests {
+//     use crate::random_rules::get_winning;
+//     use cosmwasm_std::testing::mock_env;
+//
+//     #[test]
+//     fn test_cal_random_number() {
+//         let env = mock_env();
+//         let res = get_winning(
+//             env,
+//             "test2".to_string(),
+//             vec!["1".to_string()],
+//             &vec![
+//                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
+//                 23, 24,
+//             ]
+//             .into_iter()
+//             .collect(),
+//             &100,
+//         );
+//         println!("res:{:?}", res);
+//     }
+// }

--- a/contracts/treasure/src/state.rs
+++ b/contracts/treasure/src/state.rs
@@ -2,7 +2,6 @@ use cosmwasm_std::{Addr, StdResult, Storage, Uint128, Uint64};
 use cw_storage_plus::{Item, Map};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct TreasureConfig {
@@ -11,8 +10,7 @@ pub struct TreasureConfig {
     pub start_lock_time: u64,
     pub end_lock_time: u64,
     //dust reward per second
-    pub dust_reward_per_second: Uint128,
-
+    // pub dust_reward_per_second: Uint128,
     pub withdraw_delay_duration: u64,
 
     // no delay punish coefficient
@@ -20,14 +18,14 @@ pub struct TreasureConfig {
     // punish receiver
     pub punish_receiver: Addr,
 
-    // nft start pre mint time
-    pub nft_start_pre_mint_time: u64,
-    // nft end pre mint time
-    pub nft_end_pre_mint_time: u64,
-    // nft cost dust
-    pub mint_nft_cost_dust: Uint128,
-    pub winning_num: HashSet<u64>,
-    pub mod_num: u64,
+    // // nft start pre mint time
+    // pub nft_start_pre_mint_time: u64,
+    // // nft end pre mint time
+    // pub nft_end_pre_mint_time: u64,
+    // // nft cost dust
+    // pub mint_nft_cost_dust: Uint128,
+    // pub winning_num: HashSet<u64>,
+    // pub mod_num: u64,
     pub new_gov: Option<Addr>,
 }
 
@@ -40,10 +38,10 @@ pub struct TreasureState {
     pub total_unlock_amount: Uint128,
     pub total_withdraw_amount: Uint128,
     pub total_punish_amount: Uint128,
-    pub total_cost_dust_amount: Uint128,
-
-    pub total_win_nft_num: u64,
-    pub total_lose_nft_num: u64,
+    // pub total_cost_dust_amount: Uint128,
+    //
+    // pub total_win_nft_num: u64,
+    // pub total_lose_nft_num: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -52,16 +50,15 @@ pub struct TreasureUserState {
     pub last_lock_time: u64,
     pub current_unlock_amount: Uint128,
     pub last_unlock_time: u64,
-    pub current_dust_amount: Uint128,
-
-    pub win_nft_num: u64,
-    pub lose_nft_num: u64,
-
+    // pub current_dust_amount: Uint128,
+    //
+    // pub win_nft_num: u64,
+    // pub lose_nft_num: u64,
     pub total_locked_amount: Uint128,
     pub total_unlock_amount: Uint128,
     pub total_withdraw_amount: Uint128,
     pub total_punish_amount: Uint128,
-    pub total_cost_dust_amount: Uint128,
+    // pub total_cost_dust_amount: Uint128,
 }
 
 const TREASURE_CONFIG: Item<TreasureConfig> = Item::new("treasure_config");
@@ -109,14 +106,14 @@ pub fn read_treasure_user_state(
                     last_lock_time: 0,
                     current_unlock_amount: Uint128::zero(),
                     last_unlock_time: 0,
-                    current_dust_amount: Uint128::zero(),
-                    win_nft_num: 0,
-                    lose_nft_num: 0,
+                    // current_dust_amount: Uint128::zero(),
+                    // win_nft_num: 0,
+                    // lose_nft_num: 0,
                     total_locked_amount: Uint128::zero(),
                     total_unlock_amount: Uint128::zero(),
                     total_withdraw_amount: Uint128::zero(),
                     total_punish_amount: Uint128::zero(),
-                    total_cost_dust_amount: Uint128::zero(),
+                    // total_cost_dust_amount: Uint128::zero(),
                 })
             },
             |user_state| Ok(user_state),

--- a/contracts/treasure/src/testing/integration.rs
+++ b/contracts/treasure/src/testing/integration.rs
@@ -1,4 +1,3 @@
-use crate::helper::BASE_RATE_12;
 use crate::msg::{ConfigInfosResponse, UserInfosResponse};
 use crate::testing::mock_fn::{CREATOR, PUNISH_RECEIVER};
 use crate::testing::mock_third_fn::mock_cw20_instantiate_msg;
@@ -115,7 +114,7 @@ fn test_integration() {
     assert_eq!(treasure_balance.balance, tom_lock_amount);
 
     let user_state = query_user_infos(&mut app, &treasure_contact, &tom_address).user_state;
-    assert_eq!(user_state.current_dust_amount, Uint128::zero());
+    // assert_eq!(user_state.current_dust_amount, Uint128::zero());
     assert_eq!(user_state.current_locked_amount, tom_lock_amount);
     assert_eq!(user_state.total_locked_amount, tom_lock_amount);
     assert_eq!(user_state.last_lock_time, 1688128677 + 1000u64);
@@ -125,8 +124,8 @@ fn test_integration() {
     assert_eq!(global_state.current_locked_amount, tom_lock_amount);
 
     // tom mint nft error,not enough locked token
-    let res = pre_mint_nft(&mut app, &treasure_contact, &tom_address, 1);
-    assert!(res.is_err());
+    // let res = pre_mint_nft(&mut app, &treasure_contact, &tom_address, 1);
+    // assert!(res.is_err());
 
     // tom lock 9_000_000_000 token
     let tom_lock_2_amount = Uint128::from(9_000_000_000u128);
@@ -164,8 +163,8 @@ fn test_integration() {
         global_info.state.current_locked_amount,
         tom_lock_amount + tom_lock_2_amount
     );
-    assert_eq!(global_info.state.total_lose_nft_num, 0u64);
-    assert_eq!(global_info.state.total_win_nft_num, 0u64);
+    // assert_eq!(global_info.state.total_lose_nft_num, 0u64);
+    // assert_eq!(global_info.state.total_win_nft_num, 0u64);
     assert_eq!(global_info.state.total_withdraw_amount, Uint128::zero());
     assert_eq!(global_info.state.total_punish_amount, Uint128::zero());
 
@@ -177,17 +176,17 @@ fn test_integration() {
         user_state.current_locked_amount,
         tom_lock_amount + tom_lock_2_amount
     );
-    assert_eq!(user_state.current_dust_amount, Uint128::zero());
+    // assert_eq!(user_state.current_dust_amount, Uint128::zero());
     assert_eq!(
         user_state.total_locked_amount,
         tom_lock_amount + tom_lock_2_amount
     );
-    assert_eq!(user_state.total_cost_dust_amount, Uint128::zero());
+    // assert_eq!(user_state.total_cost_dust_amount, Uint128::zero());
 
     assert_eq!(user_state.total_withdraw_amount, Uint128::zero());
     assert_eq!(user_state.total_withdraw_amount, Uint128::zero());
-    assert_eq!(user_state.win_nft_num, 0u64);
-    assert_eq!(user_state.lose_nft_num, 0u64);
+    // assert_eq!(user_state.win_nft_num, 0u64);
+    // assert_eq!(user_state.lose_nft_num, 0u64);
     assert_eq!(user_state.last_lock_time, 1688128677 + 1000u64);
 
     // tom withdraw 1_000_000_000 token error not unlock
@@ -221,13 +220,13 @@ fn test_integration() {
         user_state.current_locked_amount,
         tom_lock_amount + tom_lock_2_amount - tom_unlock_amount
     );
-    assert_eq!(
-        user_state.current_dust_amount,
-        global_info.config.dust_reward_per_second
-            * Uint128::from(1000u128)
-            * (tom_lock_amount + tom_lock_2_amount)
-            / Uint128::from(BASE_RATE_12)
-    );
+    // assert_eq!(
+    //     user_state.current_dust_amount,
+    //     global_info.config.dust_reward_per_second
+    //         * Uint128::from(1000u128)
+    //         * (tom_lock_amount + tom_lock_2_amount)
+    //         / Uint128::from(BASE_RATE_12)
+    // );
     assert_eq!(user_state.current_unlock_amount, tom_unlock_amount);
 
     let global_info = query_config_infos(&mut app, &treasure_contact);
@@ -304,31 +303,31 @@ fn test_integration() {
         block.time = Timestamp::from_seconds(1690720710 + 2000u64);
         block.height += 1000000u64;
     });
-    let user_state = query_user_infos(&mut app, &treasure_contact, &tom_address).user_state;
-    let tom_current_dust_amount = user_state.current_dust_amount;
-    println!("tom_current_dust_amount: {}", tom_current_dust_amount);
+    // let user_state = query_user_infos(&mut app, &treasure_contact, &tom_address).user_state;
+    // let tom_current_dust_amount = user_state.current_dust_amount;
+    // println!("tom_current_dust_amount: {}", tom_current_dust_amount);
     // pre nft mint
-    let pre_nft_mint_amount = 1u64;
-    let res = pre_mint_nft(
-        &mut app,
-        &treasure_contact,
-        &tom_address,
-        pre_nft_mint_amount.clone(),
-    );
-    assert!(res.is_ok());
+    // let pre_nft_mint_amount = 1u64;
+    // let res = pre_mint_nft(
+    //     &mut app,
+    //     &treasure_contact,
+    //     &tom_address,
+    //     pre_nft_mint_amount.clone(),
+    // );
+    // assert!(res.is_ok());
     // check user state
-    let user_state = query_user_infos(&mut app, &treasure_contact, &tom_address).user_state;
-    let global_info = query_config_infos(&mut app, &treasure_contact);
-    let pre_nft_mint_cost_dust = global_info.config.mint_nft_cost_dust * Uint128::one();
-    assert_eq!(
-        user_state.current_dust_amount,
-        tom_current_dust_amount - pre_nft_mint_cost_dust
-    );
-    assert_eq!(user_state.lose_nft_num, 1u64);
-    assert_eq!(
-        user_state.total_cost_dust_amount,
-        global_info.state.total_cost_dust_amount
-    );
+    // let user_state = query_user_infos(&mut app, &treasure_contact, &tom_address).user_state;
+    // let global_info = query_config_infos(&mut app, &treasure_contact);
+    // let pre_nft_mint_cost_dust = global_info.config.mint_nft_cost_dust * Uint128::one();
+    // assert_eq!(
+    //     user_state.current_dust_amount,
+    //     tom_current_dust_amount - pre_nft_mint_cost_dust
+    // );
+    // assert_eq!(user_state.lose_nft_num, 1u64);
+    // assert_eq!(
+    //     user_state.total_cost_dust_amount,
+    //     global_info.state.total_cost_dust_amount
+    // );
 }
 
 fn transfer_token(
@@ -401,26 +400,26 @@ fn user_withdraw(
     }
 }
 
-fn pre_mint_nft(
-    app: &mut App,
-    treasure_contact: &Addr,
-    user: &Addr,
-    mint_num: u64,
-) -> StdResult<Response> {
-    let pre_mint_nft_msg = crate::msg::ExecuteMsg::PreMintNft { mint_num };
-    let res = app.execute_contract(
-        user.clone(),
-        treasure_contact.clone(),
-        &pre_mint_nft_msg,
-        &[], // no funds
-    );
-    if res.is_err() {
-        println!("pre_mint_nft error: {:?}", res);
-        Err(StdError::generic_err("pre_mint_nft error"))
-    } else {
-        Ok(Response::default())
-    }
-}
+// fn pre_mint_nft(
+//     app: &mut App,
+//     treasure_contact: &Addr,
+//     user: &Addr,
+//     mint_num: u64,
+// ) -> StdResult<Response> {
+//     let pre_mint_nft_msg = crate::msg::ExecuteMsg::PreMintNft { mint_num };
+//     let res = app.execute_contract(
+//         user.clone(),
+//         treasure_contact.clone(),
+//         &pre_mint_nft_msg,
+//         &[], // no funds
+//     );
+//     if res.is_err() {
+//         println!("pre_mint_nft error: {:?}", res);
+//         Err(StdError::generic_err("pre_mint_nft error"))
+//     } else {
+//         Ok(Response::default())
+//     }
+// }
 
 fn user_lock(
     user: &Addr,

--- a/contracts/treasure/src/testing/mock_fn.rs
+++ b/contracts/treasure/src/testing/mock_fn.rs
@@ -4,29 +4,28 @@ use cosmwasm_std::testing::{
     mock_dependencies, mock_env, mock_info, MockApi, MockQuerier, MockStorage,
 };
 use cosmwasm_std::{Addr, Env, MessageInfo, OwnedDeps, Response, Uint128};
-use std::collections::HashSet;
 
 pub const CREATOR: &str = "creator";
 pub const LOCK_TOKEN: &str = "lock_token";
 pub const PUNISH_RECEIVER: &str = "punish_receiver";
 
 pub fn mock_instantiate_msg(lock_token: Addr) -> InstantiateMsg {
-    let winning_num: HashSet<u64> = (0..25).collect();
+    // let winning_num: HashSet<u64> = (0..25).collect();
 
     InstantiateMsg {
         gov: None,
         lock_token,
         start_lock_time: 1688128677,
         end_lock_time: 1689720710,
-        dust_reward_per_second: Uint128::from(16534391u128), // 7days reward 10 dust
+        // dust_reward_per_second: Uint128::from(16534391u128), // 7days reward 10 dust
         withdraw_delay_duration: 86400 * 14,
-        winning_num,
-        mod_num: 100,
+        // winning_num,
+        // mod_num: 100,
         punish_receiver: Addr::unchecked(PUNISH_RECEIVER.to_string()),
-        nft_start_pre_mint_time: 1690520710,
-        nft_end_pre_mint_time: 1699620710,
+        // nft_start_pre_mint_time: 1690520710,
+        // nft_end_pre_mint_time: 1699620710,
         no_delay_punish_coefficient: Uint128::from(300000u128),
-        mint_nft_cost_dust: Uint128::from(1_000_000u128 * 10_000u128),
+        // mint_nft_cost_dust: Uint128::from(1_000_000u128 * 10_000u128),
     }
 }
 

--- a/contracts/treasure/src/testing/tests.rs
+++ b/contracts/treasure/src/testing/tests.rs
@@ -2,7 +2,6 @@ use crate::handler::update_config;
 use crate::msg::TreasureConfigMsg;
 use crate::testing::mock_fn::{mock_instantiate, mock_instantiate_msg, LOCK_TOKEN};
 use cosmwasm_std::{Addr, Uint128};
-use std::collections::HashSet;
 
 #[test]
 fn test_instantiate() {
@@ -16,24 +15,24 @@ fn test_instantiate() {
 fn test_update_config() {
     let msg = mock_instantiate_msg(Addr::unchecked(LOCK_TOKEN.clone()));
     let (mut deps, env, info, _) = mock_instantiate(msg.clone());
-    let new_winning_num: HashSet<u64> = (75..100).collect();
+    // let new_winning_num: HashSet<u64> = (75..100).collect();
     let res = update_config(
         deps.as_mut(),
         env.clone(),
         info.clone(),
         TreasureConfigMsg {
             lock_token: Option::from(Addr::unchecked("new_lock_token".to_string())),
-            start_lock_time: Option::from(11111),
-            end_lock_time: Option::from(11112),
-            dust_reward_per_second: Option::from(Uint128::from(10_000_000u128)),
+            start_lock_time: Option::from(1572797419),
+            end_lock_time: Option::from(1581797419),
+            // dust_reward_per_second: Option::from(Uint128::from(10_000_000u128)),
             withdraw_delay_duration: Option::from(11114u64),
-            winning_num: Option::from(new_winning_num.clone()),
-            mod_num: Option::from(11117u64),
+            // winning_num: Option::from(new_winning_num.clone()),
+            // mod_num: Option::from(11117u64),
             punish_receiver: Option::from(Addr::unchecked("new_punish_receiver".to_string())),
-            nft_start_pre_mint_time: Option::from(11117),
-            nft_end_pre_mint_time: Option::from(11118),
+            // nft_start_pre_mint_time: Option::from(11117),
+            // nft_end_pre_mint_time: Option::from(11118),
             no_delay_punish_coefficient: Option::from(Uint128::from(11115u128)),
-            mint_nft_cost_dust: Option::from(Uint128::from(11116u128)),
+            // mint_nft_cost_dust: Option::from(Uint128::from(11116u128)),
         },
     )
     .unwrap();
@@ -48,28 +47,28 @@ fn test_update_config() {
         new_config.config.lock_token,
         Addr::unchecked("new_lock_token".to_string())
     );
-    assert_eq!(new_config.config.start_lock_time, 11111);
-    assert_eq!(new_config.config.end_lock_time, 11112);
-    assert_eq!(
-        new_config.config.dust_reward_per_second,
-        Uint128::from(10_000_000u128)
-    );
+    assert_eq!(new_config.config.start_lock_time, 1572797419);
+    assert_eq!(new_config.config.end_lock_time, 1581797419);
+    // assert_eq!(
+    //     new_config.config.dust_reward_per_second,
+    //     Uint128::from(10_000_000u128)
+    // );
     assert_eq!(new_config.config.withdraw_delay_duration, 11114u64);
 
-    assert_eq!(new_config.config.winning_num, new_winning_num);
-    assert_eq!(new_config.config.mod_num, 11117u64);
+    // assert_eq!(new_config.config.winning_num, new_winning_num);
+    // assert_eq!(new_config.config.mod_num, 11117u64);
     assert_eq!(
         new_config.config.punish_receiver,
         Addr::unchecked("new_punish_receiver".to_string())
     );
-    assert_eq!(new_config.config.nft_start_pre_mint_time, 11117);
-    assert_eq!(new_config.config.nft_end_pre_mint_time, 11118);
+    // assert_eq!(new_config.config.nft_start_pre_mint_time, 11117);
+    // assert_eq!(new_config.config.nft_end_pre_mint_time, 11118);
     assert_eq!(
         new_config.config.no_delay_punish_coefficient,
         Uint128::from(11115u128)
     );
-    assert_eq!(
-        new_config.config.mint_nft_cost_dust,
-        Uint128::from(11116u128)
-    );
+    // assert_eq!(
+    //     new_config.config.mint_nft_cost_dust,
+    //     Uint128::from(11116u128)
+    // );
 }


### PR DESCRIPTION
Fixed issues 19 (Delete this business block)
The get_winning function in treasure contract uses the following parameters as a source of randomness to determine the winning numbers when pre-minting NFTs:

Block time
Block height
Position of the transaction in the block
Although those parameters are volatile and make it harder to guess the winning numbers, they are not a reliable source of randomness from a security perspective.

It's recommended to use an oracle that provides a safe and secure entropy source, e.g.: Nois.