### PR TITLE
Immutable variables can be changed in staking contract

### DIFF
--- a/contracts/staking/src/handler.rs
+++ b/contracts/staking/src/handler.rs
@@ -28,17 +28,17 @@ pub fn update_staking_config(
     let mut attrs = vec![];
     attrs.push(attr("action", "update_staking_config"));
 
-    if let Some(staking_token) = update_struct.staking_token {
-        deps.api.addr_validate(staking_token.clone().as_str())?; // validate staking token address
-        staking_config.staking_token = staking_token.clone();
-        attrs.push(attr("staking_token", staking_token.to_string()));
-    }
-
-    if let Some(rewards_token) = update_struct.rewards_token {
-        deps.api.addr_validate(rewards_token.clone().as_str())?; // validate rewards token address
-        staking_config.rewards_token = rewards_token.clone();
-        attrs.push(attr("rewards_token", rewards_token.to_string()));
-    }
+    // if let Some(staking_token) = update_struct.staking_token {
+    //     deps.api.addr_validate(staking_token.clone().as_str())?; // validate staking token address
+    //     staking_config.staking_token = staking_token.clone();
+    //     attrs.push(attr("staking_token", staking_token.to_string()));
+    // }
+    //
+    // if let Some(rewards_token) = update_struct.rewards_token {
+    //     deps.api.addr_validate(rewards_token.clone().as_str())?; // validate rewards token address
+    //     staking_config.rewards_token = rewards_token.clone();
+    //     attrs.push(attr("rewards_token", rewards_token.to_string()));
+    // }
 
     if let Some(boost) = update_struct.boost {
         deps.api.addr_validate(boost.clone().as_str())?; // validate boost address

--- a/contracts/staking/src/msg.rs
+++ b/contracts/staking/src/msg.rs
@@ -4,8 +4,8 @@ use cw20::Cw20ReceiveMsg;
 
 #[cw_serde]
 pub struct UpdateStakingConfigStruct {
-    pub staking_token: Option<Addr>,
-    pub rewards_token: Option<Addr>,
+    // pub staking_token: Option<Addr>,
+    // pub rewards_token: Option<Addr>,
     pub boost: Option<Addr>,
     pub fund: Option<Addr>,
     pub reward_controller_addr: Option<Addr>,

--- a/contracts/staking/src/testing/tests.rs
+++ b/contracts/staking/src/testing/tests.rs
@@ -30,8 +30,8 @@ fn test_update_staking_config() {
     let msg = mock_instantiate_msg(staking_token, rewards_token, boost, fund);
     let (mut deps, _, info, _) = mock_instantiate(msg.clone());
     let update_config_msg = UpdateStakingConfigStruct {
-        staking_token: Some(Addr::unchecked("new_staking_token".to_string())),
-        rewards_token: Some(Addr::unchecked("new_rewards_token".to_string())),
+        // staking_token: Some(Addr::unchecked("new_staking_token".to_string())),
+        // rewards_token: Some(Addr::unchecked("new_rewards_token".to_string())),
         boost: Some(Addr::unchecked("new_boost".to_string())),
         fund: Some(Addr::unchecked("new_fund".to_string())),
         reward_controller_addr: Some(Addr::unchecked("new_reward_controller_addr".to_string())),
@@ -40,14 +40,14 @@ fn test_update_staking_config() {
     assert!(res.is_ok());
     let staking_config = read_staking_config(&deps.storage).unwrap();
     assert_eq!(staking_config.gov, Addr::unchecked("creator".to_string()));
-    assert_eq!(
-        staking_config.staking_token,
-        Addr::unchecked("new_staking_token".to_string())
-    );
-    assert_eq!(
-        staking_config.rewards_token,
-        Addr::unchecked("new_rewards_token".to_string())
-    );
+    // assert_eq!(
+    //     staking_config.staking_token,
+    //     Addr::unchecked("new_staking_token".to_string())
+    // );
+    // assert_eq!(
+    //     staking_config.rewards_token,
+    //     Addr::unchecked("new_rewards_token".to_string())
+    // );
     assert_eq!(
         staking_config.boost,
         Addr::unchecked("new_boost".to_string())


### PR DESCRIPTION
Fixed issues 20
The update_staking_config function in staking contract allows to update the values of staking_token and rewards_token variables, which should be immutable.