### PR TITLE
Claimable time is not validated in fund contract

### DIFF
--- a/contracts/fund/src/handler.rs
+++ b/contracts/fund/src/handler.rs
@@ -24,6 +24,7 @@ use cw20::Cw20ReceiveMsg;
  */
 pub fn update_fund_config(
     deps: DepsMut,
+    env: Env,
     info: MessageInfo,
     msg: UpdateConfigMsg,
 ) -> StdResult<Response> {
@@ -55,6 +56,11 @@ pub fn update_fund_config(
         attrs.push(attr("kusd_reward_addr", kusd_reward_addr.to_string()));
     }
     if let Some(claim_able_time) = msg.claim_able_time {
+        if claim_able_time.u64() <= env.block.time.seconds() {
+            return Err(StdError::generic_err(
+                "claim_able_time must be greater than current time",
+            ));
+        }
         config.claim_able_time = claim_able_time.clone();
         attrs.push(attr("claim_able_time", claim_able_time.to_string()));
     }

--- a/contracts/fund/src/testing/integration.rs
+++ b/contracts/fund/src/testing/integration.rs
@@ -132,6 +132,12 @@ fn test_integration() {
 
     // unstake
     let unstake_amount = 2592000u128;
+
+    app.update_block(|block| {
+        block.time = block.time.plus_seconds(300000000u64);
+        block.height += 300000000u64;
+    });
+
     unstake(
         &creator,
         &mut app,
@@ -282,6 +288,7 @@ fn unstake(creator: &Addr, app: &mut App, test_contract_addr: &Addr, unstake_amo
         &unstake_msg,
         &[],
     );
+
     assert!(res.is_ok());
 }
 
@@ -329,7 +336,6 @@ fn add_seilor_and_ve_seilor_role_to_fund(
 ) {
     let update_config = seilor::msg::ExecuteMsg::UpdateConfig {
         fund: Some(fund.clone()),
-        gov: None,
         distribute: None,
     };
 
@@ -339,7 +345,6 @@ fn add_seilor_and_ve_seilor_role_to_fund(
     let update_config = ve_seilor::msg::ExecuteMsg::UpdateConfig {
         max_minted: None,
         fund: Some(fund.clone()),
-        gov: None,
     };
 
     let res = app.execute_contract(

--- a/contracts/fund/src/testing/mock_fn.rs
+++ b/contracts/fund/src/testing/mock_fn.rs
@@ -1,7 +1,9 @@
-use cosmwasm_std::{Addr, Env, MessageInfo, OwnedDeps, Response, Uint64};
-use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info, MockApi, MockQuerier, MockStorage};
 use crate::contract::instantiate;
 use crate::msg::InstantiateMsg;
+use cosmwasm_std::testing::{
+    mock_dependencies, mock_env, mock_info, MockApi, MockQuerier, MockStorage,
+};
+use cosmwasm_std::{Addr, Env, MessageInfo, OwnedDeps, Response, Uint64};
 
 pub const CREATOR: &str = "creator";
 pub const KUSD_DENOM: &str = "factory/token";
@@ -15,13 +17,19 @@ pub fn mock_instantiate_msg(seilor_addr: Addr, ve_seilor_addr: Addr) -> Instanti
         kusd_denom: KUSD_DENOM.to_string(),
         kusd_reward_addr: Addr::unchecked(KUSD_REWARD_ADDR),
         exit_cycle: Uint64::from(2592000u64),
-        claim_able_time: Uint64::from(1687190400u64),
+        claim_able_time: Uint64::from(1689190400u64),
     };
     msg
 }
 
-pub fn mock_instantiate(msg: InstantiateMsg) -> (OwnedDeps<MockStorage, MockApi, MockQuerier>,
-                                                 Env, MessageInfo, Response) {
+pub fn mock_instantiate(
+    msg: InstantiateMsg,
+) -> (
+    OwnedDeps<MockStorage, MockApi, MockQuerier>,
+    Env,
+    MessageInfo,
+    Response,
+) {
     let mut deps = mock_dependencies();
     let env = mock_env();
     let info = mock_info(CREATOR, &[]);

--- a/contracts/fund/src/testing/tests.rs
+++ b/contracts/fund/src/testing/tests.rs
@@ -34,7 +34,7 @@ fn test_instantiate() {
     assert_eq!(config.kusd_reward_total_paid_amount, Uint128::zero());
     assert_eq!(config.reward_per_token_stored, Uint128::zero());
     assert_eq!(config.exit_cycle, Uint64::from(2592000u64));
-    assert_eq!(config.claim_able_time, Uint64::from(1687190400u64));
+    assert_eq!(config.claim_able_time, Uint64::from(1689190400u64));
 }
 
 #[test]
@@ -42,10 +42,10 @@ fn test_update_fund_config() {
     let seilor_addr = Addr::unchecked("seilor".to_string());
     let ve_seilor_addr = Addr::unchecked("ve_seilor".to_string());
     let msg = mock_instantiate_msg(seilor_addr.clone(), ve_seilor_addr.clone());
-    let (mut deps, _env, _info, _res) = mock_instantiate(msg);
+    let (mut deps, env, _info, _res) = mock_instantiate(msg);
 
     // Update the config
-    let update_msg = UpdateConfigMsg {
+    let mut update_msg = UpdateConfigMsg {
         ve_seilor_addr: Option::from(Addr::unchecked("new_ve_seilor")),
         seilor_addr: Option::from(Addr::unchecked("new_seilor")),
         kusd_denom: Option::from("new_kusd".to_string()),
@@ -53,10 +53,11 @@ fn test_update_fund_config() {
         claim_able_time: Option::from(Uint64::from(20u64)),
     };
     let info = mock_info("owner2", &[]);
-    let res = update_fund_config(deps.as_mut(), info.clone(), update_msg.clone());
+    let res = update_fund_config(deps.as_mut(), env.clone(), info.clone(), update_msg.clone());
     assert!(res.is_err());
     let info = mock_info(CREATOR, &[]);
-    let res = update_fund_config(deps.as_mut(), info.clone(), update_msg.clone());
+    update_msg.claim_able_time = Option::from(Uint64::from(1689190401u64));
+    let res = update_fund_config(deps.as_mut(), env.clone(), info.clone(), update_msg.clone());
     assert!(res.is_ok());
     let config: FundConfigResponse = fund_config(deps.as_ref()).unwrap();
     assert_eq!(


### PR DESCRIPTION
Fixed issues 27
The instantiate and update_fund_config functions in fund contract do not validate that the claim_able_time is greater than current block time.